### PR TITLE
fix: resolve release SHAs from tags

### DIFF
--- a/core/api/check-updates.ts
+++ b/core/api/check-updates.ts
@@ -266,13 +266,16 @@ export async function checkUpdates(
               }
             }
 
-            if (!sha && version) {
+            if (version) {
+              let releaseSha = sha
               try {
-                sha = await client.getTagSha(owner, repo, version)
+                let tagSha = await client.getTagSha(owner, repo, version)
+                sha = tagSha ?? releaseSha
               } catch {
                 /**
-                 * Ignore SHA fetch errors.
+                 * Ignore SHA fetch errors and keep the release SHA as fallback.
                  */
+                sha = releaseSha
               }
             }
             return [

--- a/core/api/check-updates.ts
+++ b/core/api/check-updates.ts
@@ -250,7 +250,11 @@ export async function checkUpdates(
                     if (!tagSha && tagVersion) {
                       try {
                         tagSha = await client.getTagSha(owner, repo, tagVersion)
-                      } catch {}
+                      } catch (error) {
+                        if (isRateLimitError(error)) {
+                          throw error
+                        }
+                      }
                     }
                     return [
                       ...results,
@@ -271,7 +275,10 @@ export async function checkUpdates(
               try {
                 let tagSha = await client.getTagSha(owner, repo, version)
                 sha = tagSha ?? releaseSha
-              } catch {
+              } catch (error) {
+                if (isRateLimitError(error)) {
+                  throw error
+                }
                 /**
                  * Ignore SHA fetch errors and keep the release SHA as fallback.
                  */
@@ -326,7 +333,10 @@ export async function checkUpdates(
             if (!sha && version) {
               try {
                 sha = await client.getTagSha(owner, repo, version)
-              } catch {
+              } catch (error) {
+                if (isRateLimitError(error)) {
+                  throw error
+                }
                 /**
                  * Ignore SHA fetch errors.
                  */
@@ -587,4 +597,8 @@ function isSha(value: undefined | string | null): boolean {
    * Check if it matches SHA pattern (7-40 hex characters).
    */
   return /^[0-9a-f]{7,40}$/iu.test(normalized)
+}
+
+function isRateLimitError(error: unknown): error is Error {
+  return error instanceof Error && error.name === 'GitHubRateLimitError'
 }

--- a/core/api/get-all-releases.ts
+++ b/core/api/get-all-releases.ts
@@ -8,7 +8,8 @@ import { makeRequest } from './make-request'
  * Fetch releases for a repository.
  *
  * Resolves SHA only for the first returned release via target_commitish when it
- * looks like a SHA; further enrichment happens at higher levels when needed.
+ * looks like a SHA; callers can resolve the tag via git refs later when
+ * pinning.
  *
  * @param context - Client context.
  * @param parameters - Request parameters.

--- a/core/api/get-latest-release.ts
+++ b/core/api/get-latest-release.ts
@@ -7,9 +7,9 @@ import { makeRequest } from './make-request'
 /**
  * Fetch the latest release for a repository.
  *
- * If the latest release does not exist (404), returns null. The commit SHA is
- * taken from target_commitish only when it looks like a SHA; otherwise SHA is
- * left null and may be resolved later via tag lookups.
+ * If the latest release does not exist (404), returns null. The commit SHA may
+ * be taken from target_commitish when it looks like a SHA; callers can resolve
+ * the tag via git refs later when pinning.
  *
  * @param context - Client context.
  * @param owner - Repository owner.

--- a/test/api/check-updates.test.ts
+++ b/test/api/check-updates.test.ts
@@ -511,9 +511,9 @@ describe('checkUpdates', () => {
         publishedAt: new Date('2024-01-01'),
         isPrerelease: false,
         description: null,
-        version: 'v1',
         /* Cspell:disable-next-line */
-        sha: 'relsha',
+        sha: 'releaseSha',
+        version: 'v1',
         name: 'v1',
         url: 'u',
       }),
@@ -594,9 +594,9 @@ describe('checkUpdates', () => {
         publishedAt: new Date('2024-01-01'),
         isPrerelease: false,
         description: null,
-        version: 'v1',
         /* Cspell:disable-next-line */
-        sha: 'relsha',
+        sha: 'releaseSha',
+        version: 'v1',
         name: 'v1',
         url: 'u',
       }),
@@ -636,9 +636,9 @@ describe('checkUpdates', () => {
         publishedAt: new Date('2024-01-01'),
         isPrerelease: false,
         description: null,
-        version: 'v1',
         /* Cspell:disable-next-line */
-        sha: 'relsha',
+        sha: 'releaseSha',
+        version: 'v1',
         name: 'v1',
         url: 'u',
       }),
@@ -717,6 +717,47 @@ describe('checkUpdates', () => {
     })
   })
 
+  it('release with empty tag_name and no tags skips release SHA resolution', async () => {
+    let client: GitHubClient = {
+      getLatestRelease: vi.fn().mockResolvedValue({
+        publishedAt: new Date('2024-01-01'),
+        isPrerelease: false,
+        description: null,
+        sha: 'releaseSha',
+        version: '',
+        name: '',
+        url: 'u',
+      }),
+      getAllReleases: vi.fn().mockResolvedValue([]),
+      getRefType: vi.fn().mockResolvedValue('tag'),
+      getAllTags: vi.fn().mockResolvedValue([]),
+      shouldWaitForRateLimit: vi.fn(),
+      getRateLimitStatus: vi.fn(),
+      getTagInfo: vi.fn(),
+      getTagSha: vi.fn(),
+    }
+    vi.mocked(createGitHubClient).mockReturnValue(client)
+
+    let actions: GitHubAction[] = [
+      {
+        uses: 'owner/repo@v0.1.0',
+        ref: 'owner/repo@v0.1.0',
+        name: 'owner/repo',
+        version: 'v0.1.0',
+        type: 'external',
+      },
+    ]
+
+    let result = await checkUpdates(actions)
+    expect(client.getAllTags).toHaveBeenCalledOnce()
+    expect(client.getTagSha).not.toHaveBeenCalled()
+    expect(result[0]).toMatchObject({
+      latestSha: 'releaseSha',
+      latestVersion: '',
+      hasUpdate: false,
+    })
+  })
+
   it('release v1 flow: getTagSha error when best tag has no sha results in null (covers catch {})', async () => {
     let client: GitHubClient = {
       getLatestRelease: vi.fn().mockResolvedValue({
@@ -760,15 +801,59 @@ describe('checkUpdates', () => {
     })
   })
 
-  it('prefers equally-versioned specific tag (v1.0.0) over release v1', async () => {
+  it('release v1 flow propagates rate-limit error from best tag SHA lookup', async () => {
+    let rateLimitError: { name: string } & Error = Object.assign(
+      new Error('rate'),
+      { name: 'GitHubRateLimitError' },
+    )
     let client: GitHubClient = {
       getLatestRelease: vi.fn().mockResolvedValue({
         publishedAt: new Date('2024-01-01'),
         isPrerelease: false,
         description: null,
         version: 'v1',
+        name: 'v1',
+        sha: null,
+        url: 'u',
+      }),
+      getAllTags: vi.fn().mockResolvedValue([
+        { tag: 'v2.0.0', message: null, date: null, sha: '' },
+        { tag: 'v1.5.0', message: null, date: null, sha: 'old' },
+      ]),
+      getTagSha: vi.fn().mockRejectedValue(rateLimitError),
+      getAllReleases: vi.fn().mockResolvedValue([]),
+      getRefType: vi.fn().mockResolvedValue('tag'),
+      shouldWaitForRateLimit: vi.fn(),
+      getRateLimitStatus: vi.fn(),
+      getTagInfo: vi.fn(),
+    }
+    vi.mocked(createGitHubClient).mockReturnValue(client)
+
+    let actions: GitHubAction[] = [
+      {
+        uses: 'owner/repo@v1',
+        ref: 'owner/repo@v1',
+        name: 'owner/repo',
+        type: 'external',
+        version: 'v1',
+      },
+    ]
+
+    await expect(checkUpdates(actions)).rejects.toHaveProperty(
+      'name',
+      'GitHubRateLimitError',
+    )
+  })
+
+  it('prefers equally-versioned specific tag (v1.0.0) over release v1', async () => {
+    let client: GitHubClient = {
+      getLatestRelease: vi.fn().mockResolvedValue({
+        publishedAt: new Date('2024-01-01'),
+        isPrerelease: false,
+        description: null,
         /* Cspell:disable-next-line */
-        sha: 'relsha',
+        sha: 'releaseSha',
+        version: 'v1',
         name: 'v1',
         url: 'u',
       }),
@@ -812,9 +897,9 @@ describe('checkUpdates', () => {
         publishedAt: new Date('2024-01-01'),
         isPrerelease: false,
         description: null,
-        version: 'v1',
         /* Cspell:disable-next-line */
-        sha: 'relsha',
+        sha: 'releaseSha',
+        version: 'v1',
         name: 'v1',
         url: 'u',
       }),
@@ -1014,6 +1099,43 @@ describe('checkUpdates', () => {
       latestVersion: 'v3.0.0',
       latestSha: null,
     })
+  })
+
+  it('propagates rate-limit error in tags-only flow when best tag SHA lookup fails', async () => {
+    let rateLimitError: { name: string } & Error = Object.assign(
+      new Error('rate'),
+      { name: 'GitHubRateLimitError' },
+    )
+    let client: GitHubClient = {
+      getAllTags: vi
+        .fn()
+        .mockResolvedValue([
+          { tag: 'v3.0.0', message: null, date: null, sha: '' },
+        ]),
+      getTagSha: vi.fn().mockRejectedValue(rateLimitError),
+      getLatestRelease: vi.fn().mockResolvedValue(null),
+      getAllReleases: vi.fn().mockResolvedValue([]),
+      getRefType: vi.fn().mockResolvedValue('tag'),
+      shouldWaitForRateLimit: vi.fn(),
+      getRateLimitStatus: vi.fn(),
+      getTagInfo: vi.fn(),
+    }
+    vi.mocked(createGitHubClient).mockReturnValue(client)
+
+    let actions: GitHubAction[] = [
+      {
+        uses: 'owner/repo@v2.0.0',
+        ref: 'owner/repo@v2.0.0',
+        name: 'owner/repo',
+        version: 'v2.0.0',
+        type: 'external',
+      },
+    ]
+
+    await expect(checkUpdates(actions)).rejects.toHaveProperty(
+      'name',
+      'GitHubRateLimitError',
+    )
   })
 
   it('fetches SHA for best tag when tag SHA is missing in tags list (no releases)', async () => {

--- a/test/api/check-updates.test.ts
+++ b/test/api/check-updates.test.ts
@@ -1156,12 +1156,12 @@ describe('checkUpdates', () => {
   it('prefers resolved tag SHA over release metadata SHA', async () => {
     let client: GitHubClient = {
       getLatestRelease: vi.fn().mockResolvedValue({
+        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
         publishedAt: new Date('2024-03-29'),
         isPrerelease: false,
         version: 'v5.1.0',
         description: null,
         name: 'v5.1.0',
-        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
         url: 'u',
       }),
       getTagSha: vi
@@ -1189,8 +1189,8 @@ describe('checkUpdates', () => {
     let result = await checkUpdates(actions)
     expect(client.getTagSha).toHaveBeenCalledWith('owner', 'repo', 'v5.1.0')
     expect(result[0]).toMatchObject({
-      latestVersion: 'v5.1.0',
       latestSha: '63ac138db421d586de61f7f5ac3bcef6a2e6c78c',
+      latestVersion: 'v5.1.0',
       hasUpdate: true,
     })
   })
@@ -1198,16 +1198,16 @@ describe('checkUpdates', () => {
   it('falls back to release metadata SHA when tag SHA resolves to null', async () => {
     let client: GitHubClient = {
       getLatestRelease: vi.fn().mockResolvedValue({
+        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
         publishedAt: new Date('2024-03-29'),
         isPrerelease: false,
         version: 'v5.1.0',
         description: null,
         name: 'v5.1.0',
-        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
         url: 'u',
       }),
-      getTagSha: vi.fn().mockResolvedValue(null),
       getRefType: vi.fn().mockResolvedValue('tag'),
+      getTagSha: vi.fn().mockResolvedValue(null),
       shouldWaitForRateLimit: vi.fn(),
       getRateLimitStatus: vi.fn(),
       getAllReleases: vi.fn(),
@@ -1228,8 +1228,8 @@ describe('checkUpdates', () => {
 
     let result = await checkUpdates(actions)
     expect(result[0]).toMatchObject({
-      latestVersion: 'v5.1.0',
       latestSha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
+      latestVersion: 'v5.1.0',
       hasUpdate: true,
     })
   })
@@ -1237,12 +1237,12 @@ describe('checkUpdates', () => {
   it('falls back to release metadata SHA when tag resolution throws', async () => {
     let client: GitHubClient = {
       getLatestRelease: vi.fn().mockResolvedValue({
+        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
         publishedAt: new Date('2024-03-29'),
         isPrerelease: false,
         version: 'v5.1.0',
         description: null,
         name: 'v5.1.0',
-        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
         url: 'u',
       }),
       getTagSha: vi.fn().mockRejectedValue(new Error('temporary')),
@@ -1267,25 +1267,25 @@ describe('checkUpdates', () => {
 
     let result = await checkUpdates(actions)
     expect(result[0]).toMatchObject({
-      latestVersion: 'v5.1.0',
       latestSha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
+      latestVersion: 'v5.1.0',
       hasUpdate: true,
     })
   })
 
   it('propagates rate-limit error from release tag SHA lookup', async () => {
-    let rateLimitError: Error & { name: string } = Object.assign(
+    let rateLimitError: { name: string } & Error = Object.assign(
       new Error('rate'),
       { name: 'GitHubRateLimitError' },
     )
     let client: GitHubClient = {
       getLatestRelease: vi.fn().mockResolvedValue({
+        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
         publishedAt: new Date('2024-03-29'),
         isPrerelease: false,
         version: 'v5.1.0',
         description: null,
         name: 'v5.1.0',
-        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
         url: 'u',
       }),
       getTagSha: vi.fn().mockRejectedValue(rateLimitError),
@@ -1304,41 +1304,6 @@ describe('checkUpdates', () => {
         ref: 'owner/repo@v5.0.0',
         name: 'owner/repo',
         version: 'v5.0.0',
-        type: 'external',
-      },
-    ]
-
-    await expect(checkUpdates(actions)).rejects.toHaveProperty(
-      'name',
-      'GitHubRateLimitError',
-    )
-  })
-
-  it('propagates rate-limit error from tags-only SHA lookup', async () => {
-    let rateLimitError: Error & { name: string } = Object.assign(
-      new Error('rate'),
-      { name: 'GitHubRateLimitError' },
-    )
-    let client: GitHubClient = {
-      getAllTags: vi.fn().mockResolvedValue([
-        { tag: 'v3.0.0', message: null, date: null, sha: '' },
-      ]),
-      getTagSha: vi.fn().mockRejectedValue(rateLimitError),
-      getLatestRelease: vi.fn().mockResolvedValue(null),
-      getAllReleases: vi.fn().mockResolvedValue([]),
-      getRefType: vi.fn().mockResolvedValue('tag'),
-      shouldWaitForRateLimit: vi.fn(),
-      getRateLimitStatus: vi.fn(),
-      getTagInfo: vi.fn(),
-    }
-    vi.mocked(createGitHubClient).mockReturnValue(client)
-
-    let actions: GitHubAction[] = [
-      {
-        uses: 'owner/repo@v2.0.0',
-        ref: 'owner/repo@v2.0.0',
-        name: 'owner/repo',
-        version: 'v2.0.0',
         type: 'external',
       },
     ]

--- a/test/api/check-updates.test.ts
+++ b/test/api/check-updates.test.ts
@@ -1153,6 +1153,126 @@ describe('checkUpdates', () => {
     expect(result[0]).toMatchObject({ latestSha: 'sha-from-tag' })
   })
 
+  it('prefers resolved tag SHA over release metadata SHA', async () => {
+    let client: GitHubClient = {
+      getLatestRelease: vi.fn().mockResolvedValue({
+        publishedAt: new Date('2024-03-29'),
+        isPrerelease: false,
+        version: 'v5.1.0',
+        description: null,
+        name: 'v5.1.0',
+        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
+        url: 'u',
+      }),
+      getTagSha: vi
+        .fn()
+        .mockResolvedValue('63ac138db421d586de61f7f5ac3bcef6a2e6c78c'),
+      getRefType: vi.fn().mockResolvedValue('tag'),
+      shouldWaitForRateLimit: vi.fn(),
+      getRateLimitStatus: vi.fn(),
+      getAllReleases: vi.fn(),
+      getAllTags: vi.fn(),
+      getTagInfo: vi.fn(),
+    }
+    vi.mocked(createGitHubClient).mockReturnValue(client)
+
+    let actions: GitHubAction[] = [
+      {
+        uses: 'owner/repo@v5.0.0',
+        ref: 'owner/repo@v5.0.0',
+        name: 'owner/repo',
+        version: 'v5.0.0',
+        type: 'external',
+      },
+    ]
+
+    let result = await checkUpdates(actions)
+    expect(client.getTagSha).toHaveBeenCalledWith('owner', 'repo', 'v5.1.0')
+    expect(result[0]).toMatchObject({
+      latestVersion: 'v5.1.0',
+      latestSha: '63ac138db421d586de61f7f5ac3bcef6a2e6c78c',
+      hasUpdate: true,
+    })
+  })
+
+  it('falls back to release metadata SHA when tag SHA resolves to null', async () => {
+    let client: GitHubClient = {
+      getLatestRelease: vi.fn().mockResolvedValue({
+        publishedAt: new Date('2024-03-29'),
+        isPrerelease: false,
+        version: 'v5.1.0',
+        description: null,
+        name: 'v5.1.0',
+        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
+        url: 'u',
+      }),
+      getTagSha: vi.fn().mockResolvedValue(null),
+      getRefType: vi.fn().mockResolvedValue('tag'),
+      shouldWaitForRateLimit: vi.fn(),
+      getRateLimitStatus: vi.fn(),
+      getAllReleases: vi.fn(),
+      getAllTags: vi.fn(),
+      getTagInfo: vi.fn(),
+    }
+    vi.mocked(createGitHubClient).mockReturnValue(client)
+
+    let actions: GitHubAction[] = [
+      {
+        uses: 'owner/repo@v5.0.0',
+        ref: 'owner/repo@v5.0.0',
+        name: 'owner/repo',
+        version: 'v5.0.0',
+        type: 'external',
+      },
+    ]
+
+    let result = await checkUpdates(actions)
+    expect(result[0]).toMatchObject({
+      latestVersion: 'v5.1.0',
+      latestSha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
+      hasUpdate: true,
+    })
+  })
+
+  it('falls back to release metadata SHA when tag resolution throws', async () => {
+    let client: GitHubClient = {
+      getLatestRelease: vi.fn().mockResolvedValue({
+        publishedAt: new Date('2024-03-29'),
+        isPrerelease: false,
+        version: 'v5.1.0',
+        description: null,
+        name: 'v5.1.0',
+        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
+        url: 'u',
+      }),
+      getTagSha: vi.fn().mockRejectedValue(new Error('temporary')),
+      getRefType: vi.fn().mockResolvedValue('tag'),
+      shouldWaitForRateLimit: vi.fn(),
+      getRateLimitStatus: vi.fn(),
+      getAllReleases: vi.fn(),
+      getAllTags: vi.fn(),
+      getTagInfo: vi.fn(),
+    }
+    vi.mocked(createGitHubClient).mockReturnValue(client)
+
+    let actions: GitHubAction[] = [
+      {
+        uses: 'owner/repo@v5.0.0',
+        ref: 'owner/repo@v5.0.0',
+        name: 'owner/repo',
+        version: 'v5.0.0',
+        type: 'external',
+      },
+    ]
+
+    let result = await checkUpdates(actions)
+    expect(result[0]).toMatchObject({
+      latestVersion: 'v5.1.0',
+      latestSha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
+      hasUpdate: true,
+    })
+  })
+
   it('propagates rate-limit error', async () => {
     let errorObject: { name: string } & Error = Object.assign(
       new Error('rate'),

--- a/test/api/check-updates.test.ts
+++ b/test/api/check-updates.test.ts
@@ -1273,6 +1273,82 @@ describe('checkUpdates', () => {
     })
   })
 
+  it('propagates rate-limit error from release tag SHA lookup', async () => {
+    let rateLimitError: Error & { name: string } = Object.assign(
+      new Error('rate'),
+      { name: 'GitHubRateLimitError' },
+    )
+    let client: GitHubClient = {
+      getLatestRelease: vi.fn().mockResolvedValue({
+        publishedAt: new Date('2024-03-29'),
+        isPrerelease: false,
+        version: 'v5.1.0',
+        description: null,
+        name: 'v5.1.0',
+        sha: 'a3ced27cc8dc211a23fe48005eaea8ac9df9400f',
+        url: 'u',
+      }),
+      getTagSha: vi.fn().mockRejectedValue(rateLimitError),
+      getRefType: vi.fn().mockResolvedValue('tag'),
+      shouldWaitForRateLimit: vi.fn(),
+      getRateLimitStatus: vi.fn(),
+      getAllReleases: vi.fn(),
+      getAllTags: vi.fn(),
+      getTagInfo: vi.fn(),
+    }
+    vi.mocked(createGitHubClient).mockReturnValue(client)
+
+    let actions: GitHubAction[] = [
+      {
+        uses: 'owner/repo@v5.0.0',
+        ref: 'owner/repo@v5.0.0',
+        name: 'owner/repo',
+        version: 'v5.0.0',
+        type: 'external',
+      },
+    ]
+
+    await expect(checkUpdates(actions)).rejects.toHaveProperty(
+      'name',
+      'GitHubRateLimitError',
+    )
+  })
+
+  it('propagates rate-limit error from tags-only SHA lookup', async () => {
+    let rateLimitError: Error & { name: string } = Object.assign(
+      new Error('rate'),
+      { name: 'GitHubRateLimitError' },
+    )
+    let client: GitHubClient = {
+      getAllTags: vi.fn().mockResolvedValue([
+        { tag: 'v3.0.0', message: null, date: null, sha: '' },
+      ]),
+      getTagSha: vi.fn().mockRejectedValue(rateLimitError),
+      getLatestRelease: vi.fn().mockResolvedValue(null),
+      getAllReleases: vi.fn().mockResolvedValue([]),
+      getRefType: vi.fn().mockResolvedValue('tag'),
+      shouldWaitForRateLimit: vi.fn(),
+      getRateLimitStatus: vi.fn(),
+      getTagInfo: vi.fn(),
+    }
+    vi.mocked(createGitHubClient).mockReturnValue(client)
+
+    let actions: GitHubAction[] = [
+      {
+        uses: 'owner/repo@v2.0.0',
+        ref: 'owner/repo@v2.0.0',
+        name: 'owner/repo',
+        version: 'v2.0.0',
+        type: 'external',
+      },
+    ]
+
+    await expect(checkUpdates(actions)).rejects.toHaveProperty(
+      'name',
+      'GitHubRateLimitError',
+    )
+  })
+
   it('propagates rate-limit error', async () => {
     let errorObject: { name: string } & Error = Object.assign(
       new Error('rate'),

--- a/types/release-info.d.ts
+++ b/types/release-info.d.ts
@@ -13,7 +13,7 @@ export interface ReleaseInfo {
   isPrerelease: boolean
 
   /**
-   * Commit SHA associated with the release tag (may be null).
+   * Commit SHA associated with the release tag when known (may be provisional).
    */
   sha: string | null
 


### PR DESCRIPTION
### Description

I found this through `typst-community/setup-typst` in another repo. After running `actions-up`, it updated the workflow to a fresh SHA, but CI failed with:

```text
Run typst-community/setup-typst@a3ced27cc8dc211a23fe48005eaea8ac9df9400f
Error: File not found: '/home/runner/work/_actions/typst-community/setup-typst/a3ced27cc8dc211a23fe48005eaea8ac9df9400f/dist/main/index.js'
```

The root cause is that `actions-up` could pin a release to `target_commitish` instead of the commit the release tag actually points to. When those differ, the tool may update workflows to a commit that does not contain the built action artifacts.

This change resolves the chosen release tag through `getTagSha()` before using a SHA for pinning. If tag lookup fails or returns `null`, it falls back to the release-provided SHA.

It also adds regression coverage for:
- preferring the tag SHA over release metadata
- falling back when tag lookup returns `null`
- falling back when tag lookup throws

### Reviewer notes

The main behavior change is in `core/api/check-updates.ts`. The other edits clarify the release SHA contract and add tests for the failure mode.

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed