### PR TITLE
fix: fall back to an older release when the cool-down holds the latest

### DIFF
--- a/cli/index.ts
+++ b/cli/index.ts
@@ -284,31 +284,20 @@ async function runUpdate(options: CLIOptions): Promise<void> {
     outdated = kept
 
     /**
-     * Filter by minimum age if publishedAt is available.
+     * Resolve the update mode and the release age cool-down together. An action
+     * held back by either constraint steps down to the newest release that
+     * clears both, and is reported as blocked only when no release does.
      */
     let minAgeMs = options.minAge * 24 * 60 * 60 * 1000
     let now = Date.now()
-    let blockedByAge: typeof outdated = []
-    outdated = outdated.filter(update => {
-      if (!update.publishedAt) {
-        return true
-      }
-      let age = now - update.publishedAt.getTime()
-      if (age < minAgeMs) {
-        blockedByAge.push(update)
-        return false
-      }
-      return true
-    })
+    let tagsCache = new Map<
+      string,
+      Awaited<ReturnType<typeof githubClient.getAllTags>>
+    >()
+    let shaCache = new Map<string, string | null>()
 
-    let blockedByMode: typeof outdated = []
-    if (mode !== 'major') {
-      let tagsCache = new Map<
-        string,
-        Awaited<ReturnType<typeof githubClient.getAllTags>>
-      >()
-      let shaCache = new Map<string, string | null>()
-      let decisions = outdated.map(update => {
+    let decisions = await Promise.all(
+      outdated.map(async update => {
         let effectiveCurrentVersion = update.currentVersion
         if (isSha(update.currentVersion)) {
           let inline = parseVersionComment(update.action.comment)
@@ -321,56 +310,73 @@ async function runUpdate(options: CLIOptions): Promise<void> {
           effectiveCurrentVersion,
           update.latestVersion,
         )
-        let allowed = (
-          mode === 'minor' ?
+        let allowedByMode =
+          mode === 'major' ||
+          (mode === 'minor' ?
             ['minor', 'patch', 'none']
-          : ['patch', 'none']).includes(level)
+          : ['patch', 'none']
+          ).includes(level)
+        let allowedByAge =
+          !update.publishedAt || now - update.publishedAt.getTime() >= minAgeMs
 
-        return { effectiveCurrentVersion, allowed, update }
-      })
-
-      let allowedByMode: typeof outdated = []
-      let compatibleFallbacks = await Promise.all(
-        decisions.map(async decision => {
-          if (decision.allowed) {
-            return { update: decision.update }
-          }
-
-          let compatible = await getCompatibleUpdate(githubClient, {
-            currentVersion: decision.effectiveCurrentVersion,
-            actionName: decision.update.action.name,
-            tagsCache,
-            shaCache,
-            mode,
-          })
-
-          if (!compatible) {
-            return { blocked: decision.update }
-          }
-
-          return {
-            update: {
-              ...decision.update,
-              latestVersion: compatible.version,
-              latestSha: compatible.sha,
-              isBreaking: false,
-              hasUpdate: true,
-            },
-          }
-        }),
-      )
-
-      for (let decision of compatibleFallbacks) {
-        if (decision.update) {
-          allowedByMode.push(decision.update)
-          continue
+        if (allowedByMode && allowedByAge) {
+          return { blockedBy: null, update }
         }
 
-        blockedByMode.push(decision.blocked)
-      }
+        let compatible = await getCompatibleUpdate(githubClient, {
+          currentVersion: effectiveCurrentVersion,
+          actionName: update.action.name,
+          tagsCache,
+          minAgeMs,
+          shaCache,
+          mode,
+          now,
+        })
 
-      outdated = allowedByMode
+        if (!compatible.update) {
+          /**
+           * The cool-down owns the outcome whenever the mode itself had a
+           * candidate to offer, so the notice names the constraint that
+           * actually held the action back.
+           */
+          let blockedBy: 'mode' | 'age' =
+            allowedByMode || compatible.reason === 'cool-down' ? 'age' : 'mode'
+          return { blockedBy, update }
+        }
+
+        return {
+          update: {
+            ...update,
+            isBreaking:
+              getUpdateLevel(
+                effectiveCurrentVersion,
+                compatible.update.version,
+              ) === 'major',
+            publishedAt: compatible.update.publishedAt,
+            latestVersion: compatible.update.version,
+            latestSha: compatible.update.sha,
+            hasUpdate: true,
+          },
+          blockedBy: null,
+        }
+      }),
+    )
+
+    let blockedByAge: typeof outdated = []
+    let blockedByMode: typeof outdated = []
+    let eligible: typeof outdated = []
+
+    for (let decision of decisions) {
+      if (decision.blockedBy === 'age') {
+        blockedByAge.push(decision.update)
+      } else if (decision.blockedBy === 'mode') {
+        blockedByMode.push(decision.update)
+      } else {
+        eligible.push(decision.update)
+      }
     }
+
+    outdated = eligible
 
     /**
      * Deduplicate resolution per action and version, so repeated occurrences

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -325,6 +325,7 @@ async function runUpdate(options: CLIOptions): Promise<void> {
 
         let compatible = await getCompatibleUpdate(githubClient, {
           currentVersion: effectiveCurrentVersion,
+          latestVersion: update.latestVersion,
           actionName: update.action.name,
           tagsCache,
           minAgeMs,

--- a/cli/index.ts
+++ b/cli/index.ts
@@ -3,6 +3,7 @@ import { resolve } from 'node:path'
 import 'node:worker_threads'
 import pc from 'picocolors'
 
+import type { CompatibleUpdate } from '../core/api/get-compatible-update'
 import type { JsonReportStatus } from './build-json-report'
 import type { ActionUpdate } from '../types/action-update'
 import type { ScanResult } from '../types/scan-result'
@@ -296,6 +297,14 @@ async function runUpdate(options: CLIOptions): Promise<void> {
     >()
     let shaCache = new Map<string, string | null>()
 
+    /**
+     * Deduplicate the compatible lookup per action and version. The same
+     * blocked action can appear in many workflows, and each uncached lookup
+     * costs a tag listing plus a date walk. Promises are stored rather than
+     * values, so occurrences that start together share one request.
+     */
+    let compatibleCache = new Map<string, Promise<CompatibleUpdate>>()
+
     let decisions = await Promise.all(
       outdated.map(async update => {
         let effectiveCurrentVersion = update.currentVersion
@@ -323,16 +332,26 @@ async function runUpdate(options: CLIOptions): Promise<void> {
           return { blockedBy: null, update }
         }
 
-        let compatible = await getCompatibleUpdate(githubClient, {
-          currentVersion: effectiveCurrentVersion,
-          latestVersion: update.latestVersion,
-          actionName: update.action.name,
-          tagsCache,
-          minAgeMs,
-          shaCache,
-          mode,
-          now,
-        })
+        let compatibleKey = [
+          update.action.name,
+          effectiveCurrentVersion,
+          update.latestVersion,
+        ].join('@')
+        let pending = compatibleCache.get(compatibleKey)
+        if (!pending) {
+          pending = getCompatibleUpdate(githubClient, {
+            currentVersion: effectiveCurrentVersion,
+            latestVersion: update.latestVersion,
+            actionName: update.action.name,
+            tagsCache,
+            minAgeMs,
+            shaCache,
+            mode,
+            now,
+          })
+          compatibleCache.set(compatibleKey, pending)
+        }
+        let compatible = await pending
 
         if (!compatible.update) {
           /**

--- a/core/api/get-compatible-update.ts
+++ b/core/api/get-compatible-update.ts
@@ -2,19 +2,60 @@ import type { GitHubClient } from '../../types/github-client'
 import type { UpdateMode } from '../../types/update-mode'
 import type { TagInfo } from '../../types/tag-info'
 
-import { findCompatibleTag } from '../versions/find-compatible-tag'
+import { findCompatibleTags } from '../versions/find-compatible-tags'
 import { getFamilyPrefix } from '../versions/get-family-prefix'
+
+/**
+ * Outcome of a compatible update lookup.
+ */
+export type CompatibleUpdate =
+  | {
+      /**
+       * Newest tag that satisfies both the update mode and the cool-down.
+       */
+      update: {
+        /**
+         * Publication date of the selected tag. Null when the cool-down did not
+         * apply, or when the date could not be determined.
+         */
+        publishedAt: Date | null
+
+        /**
+         * Commit SHA the selected tag points to, null when unresolved.
+         */
+        sha: string | null
+
+        /**
+         * Selected tag name.
+         */
+        version: string
+      }
+
+      /**
+       * No constraint held the lookup back.
+       */
+      reason: null
+    }
+  | {
+      /**
+       * Why no tag can be offered. `cool-down` means the mode allows one or
+       * more tags but every one of them is too young. `no-candidate` means no
+       * compatible tag was established: either the listing held nothing newer
+       * that the mode allows, or the listing could not be read.
+       */
+      reason: 'no-candidate' | 'cool-down'
+
+      /**
+       * Nothing to offer.
+       */
+      update: null
+    }
 
 interface GetCompatibleUpdateParameters {
   /**
    * Optional in-memory cache for resolved tag SHAs.
    */
   shaCache?: Map<string, string | null>
-
-  /**
-   * Update mode that limits which tag can be selected.
-   */
-  mode: Exclude<UpdateMode, 'major'>
 
   /**
    * Optional in-memory cache for action tags.
@@ -30,34 +71,72 @@ interface GetCompatibleUpdateParameters {
    * Action name in `owner/repo` format (path suffix is allowed).
    */
   actionName: string
+
+  /**
+   * Cool-down in milliseconds. A tag published less recently than this is
+   * passed over. Zero, the default, disables the cool-down.
+   */
+  minAgeMs?: number
+
+  /**
+   * Update mode that limits which tag can be selected.
+   */
+  mode: UpdateMode
+
+  /**
+   * Clock used to measure the cool-down, in milliseconds since the epoch.
+   * Defaults to the current time.
+   */
+  now?: number
+}
+
+/**
+ * A candidate tag together with the metadata read while ranking it.
+ */
+interface SelectedCandidate {
+  /**
+   * Publication date and commit SHA, both null when they were not read.
+   */
+  meta: { sha: string | null; date: Date | null }
+
+  /**
+   * The candidate itself.
+   */
+  candidate: TagInfo
 }
 
 /**
  * Resolve the newest compatible update for an action.
  *
+ * Both the update mode and the release age cool-down are applied here, so a tag
+ * held back by either one steps down to the newest tag that clears both instead
+ * of dropping the action.
+ *
  * @param client - GitHub client instance.
  * @param parameters - Lookup parameters.
- * @returns Compatible target version and SHA, or null when none found.
+ * @returns The selected tag, or the reason no tag qualifies.
  */
 export async function getCompatibleUpdate(
   client: GitHubClient,
   parameters: GetCompatibleUpdateParameters,
-): Promise<{ sha: string | null; version: string } | null> {
+): Promise<CompatibleUpdate> {
   let { currentVersion, actionName, mode } = parameters
+  let minAgeMs = parameters.minAgeMs ?? 0
+  let now = parameters.now ?? Date.now()
 
   let familyPrefix = getFamilyPrefix(currentVersion)
 
   if (familyPrefix === null) {
-    return null
+    return { reason: 'no-candidate', update: null }
   }
 
   let segments = actionName.split('/')
   if (segments.length < 2) {
-    return null
+    return { reason: 'no-candidate', update: null }
   }
   let [owner, repo] = segments
   if (!owner || !repo) {
-    return null
+    return { reason: 'no-candidate', update: null }
   }
 
   let tagsCache = parameters.tagsCache ?? new Map<string, TagInfo[]>()
@@ -76,32 +155,127 @@ export async function getCompatibleUpdate(
           await client.getAllTags(owner, repo, 100)
         : await client.getMatchingTagReferences(owner, repo, familyPrefix)
     } catch {
-      return null
+      return { reason: 'no-candidate', update: null }
     }
     tagsCache.set(tagsCacheKey, tags)
   }
 
-  let compatibleTag = findCompatibleTag(tags, currentVersion, mode)
-  if (!compatibleTag) {
-    return null
+  let candidates = findCompatibleTags(tags, currentVersion, mode)
+  if (candidates.length === 0) {
+    return { reason: 'no-candidate', update: null }
   }
 
-  let version = compatibleTag.tag
-  let sha = compatibleTag.sha?.length ? compatibleTag.sha : null
+  let selected =
+    minAgeMs > 0 ?
+      await selectAgedCandidate(client, {
+        candidates,
+        minAgeMs,
+        owner,
+        repo,
+        now,
+      })
+    : { meta: { date: null, sha: null }, candidate: candidates[0]! }
+
+  if (!selected) {
+    return { reason: 'cool-down', update: null }
+  }
+
+  let version = selected.candidate.tag
+  let sha =
+    selected.candidate.sha?.length ? selected.candidate.sha : selected.meta.sha
 
   if (!sha) {
     let shaCacheKey = `${actionName}@${version}`
     if (shaCache.has(shaCacheKey)) {
-      return { sha: shaCache.get(shaCacheKey) ?? null, version }
+      sha = shaCache.get(shaCacheKey) ?? null
+    } else {
+      try {
+        sha = await client.getTagSha(owner, repo, version)
+      } catch {
+        sha = null
+      }
+      shaCache.set(shaCacheKey, sha)
     }
-
-    try {
-      sha = await client.getTagSha(owner, repo, version)
-    } catch {
-      sha = null
-    }
-    shaCache.set(shaCacheKey, sha)
   }
 
-  return { version, sha }
+  return {
+    update: { publishedAt: selected.meta.date, version, sha },
+    reason: null,
+  }
+}
+
+/**
+ * Take the newest candidate that clears the cool-down.
+ *
+ * Tag listings carry no dates, so every candidate costs one lookup. The lookups
+ * are chained rather than run together, so a step-down of a single release does
+ * not pay for the whole tag history. A date that cannot be determined counts as
+ * old enough, which matches how an unknown publication date is treated
+ * elsewhere.
+ *
+ * @param client - GitHub client instance.
+ * @param parameters - Candidates and the cool-down to apply.
+ * @param parameters.candidates - Compatible tags ordered newest first.
+ * @param parameters.minAgeMs - Cool-down in milliseconds.
+ * @param parameters.owner - Repository owner.
+ * @param parameters.repo - Repository name.
+ * @param parameters.now - Clock used to measure the cool-down.
+ * @returns The first old enough candidate, or null when none qualifies.
+ */
+async function selectAgedCandidate(
+  client: GitHubClient,
+  parameters: {
+    candidates: TagInfo[]
+    minAgeMs: number
+    owner: string
+    repo: string
+    now: number
+  },
+): Promise<SelectedCandidate | null> {
+  let { candidates, minAgeMs, owner, repo, now } = parameters
+
+  return candidates.reduce<Promise<SelectedCandidate | null>>(
+    async (pending, candidate) => {
+      let selected = await pending
+      if (selected) {
+        return selected
+      }
+
+      let meta = await resolveTagMeta(client, {
+        tag: candidate.tag,
+        owner,
+        repo,
+      })
+
+      if (meta.date && now - meta.date.getTime() < minAgeMs) {
+        return null
+      }
+
+      return { candidate, meta }
+    },
+    Promise.resolve(null),
+  )
+}
+
+/**
+ * Read the publication date and commit SHA of a tag, best effort.
+ *
+ * @param client - GitHub client instance.
+ * @param parameters - Request parameters.
+ * @param parameters.owner - Repository owner.
+ * @param parameters.repo - Repository name.
+ * @param parameters.tag - Tag name to inspect.
+ * @returns Tag date and SHA, both null when the lookup fails.
+ */
+async function resolveTagMeta(
+  client: GitHubClient,
+  parameters: { owner: string; repo: string; tag: string },
+): Promise<{ sha: string | null; date: Date | null }> {
+  try {
+    let { owner, repo, tag } = parameters
+    let info = await client.getTagInfo(owner, repo, tag)
+    return { date: info?.date ?? null, sha: info?.sha ?? null }
+  } catch {
+    return { date: null, sha: null }
+  }
 }

--- a/core/api/get-compatible-update.ts
+++ b/core/api/get-compatible-update.ts
@@ -115,6 +115,8 @@ interface SelectedCandidate {
  * @param client - GitHub client instance.
  * @param parameters - Lookup parameters.
  * @returns The selected tag, or the reason no tag qualifies.
+ * @throws GitHubRateLimitError - When the cool-down needed a publication date
+ *   and the request for it was rate limited.
  */
 export async function getCompatibleUpdate(
   client: GitHubClient,
@@ -211,7 +213,8 @@ export async function getCompatibleUpdate(
  * are chained rather than run together, so a step-down of a single release does
  * not pay for the whole tag history. A date that cannot be determined counts as
  * old enough, which matches how an unknown publication date is treated
- * elsewhere.
+ * elsewhere. A rate limit is the exception: it is reported rather than read as
+ * an unknown date, because it can hide the date of every candidate at once.
  *
  * @param client - GitHub client instance.
  * @param parameters - Candidates and the cool-down to apply.
@@ -221,6 +224,7 @@ export async function getCompatibleUpdate(
  * @param parameters.repo - Repository name.
  * @param parameters.now - Clock used to measure the cool-down.
  * @returns The first old enough candidate, or null when none qualifies.
+ * @throws GitHubRateLimitError - When a candidate lookup was rate limited.
  */
 async function selectAgedCandidate(
   client: GitHubClient,
@@ -266,6 +270,9 @@ async function selectAgedCandidate(
  * @param parameters.repo - Repository name.
  * @param parameters.tag - Tag name to inspect.
  * @returns Tag date and SHA, both null when the lookup fails.
+ * @throws GitHubRateLimitError - When the request was rate limited, so the run
+ *   reports the rate limit instead of passing an undated tag off as old
+ *   enough.
  */
 async function resolveTagMeta(
   client: GitHubClient,
@@ -275,7 +282,10 @@ async function resolveTagMeta(
     let { owner, repo, tag } = parameters
     let info = await client.getTagInfo(owner, repo, tag)
     return { date: info?.date ?? null, sha: info?.sha ?? null }
-  } catch {
+  } catch (error) {
+    if (error instanceof Error && error.name === 'GitHubRateLimitError') {
+      throw error
+    }
     return { date: null, sha: null }
   }
 }

--- a/core/api/get-compatible-update.ts
+++ b/core/api/get-compatible-update.ts
@@ -68,6 +68,13 @@ interface GetCompatibleUpdateParameters {
   currentVersion: string | null
 
   /**
+   * Newest version the caller already vetted, usually the release the update
+   * check settled on. The walk never rises above it, so a tag that was never
+   * released cannot be offered. Omit it to consider every compatible tag.
+   */
+  latestVersion?: string | null
+
+  /**
    * Action name in `owner/repo` format (path suffix is allowed).
    */
   actionName: string
@@ -162,7 +169,10 @@ export async function getCompatibleUpdate(
     tagsCache.set(tagsCacheKey, tags)
   }
 
-  let candidates = findCompatibleTags(tags, currentVersion, mode)
+  let candidates = findCompatibleTags(tags, currentVersion, {
+    latestVersion: parameters.latestVersion,
+    mode,
+  })
   if (candidates.length === 0) {
     return { reason: 'no-candidate', update: null }
   }

--- a/core/api/get-tag-info.ts
+++ b/core/api/get-tag-info.ts
@@ -9,6 +9,11 @@ import { makeRequest } from './make-request'
  * metadata (date/message), then resolves the commit SHA via refs. Falls back to
  * refs-only lookup when release-by-tag is not found.
  *
+ * Every metadata request here is best effort, but a rate limit is reported
+ * rather than absorbed, on every path. Absorbing it would answer with a tag
+ * that carries no publication date, which the caller reads as a tag old enough
+ * to offer.
+ *
  * @param context - Client context.
  * @param parameters - Request parameters.
  * @param parameters.owner - Repository owner.
@@ -74,7 +79,10 @@ export async function getTagInfo(
             if (!message && typeof tagData.message === 'string') {
               ;({ message } = tagData)
             }
-          } catch {
+          } catch (tagObjectError: unknown) {
+            if (isRateLimit(tagObjectError)) {
+              throw tagObjectError
+            }
             sha = objectSha
           }
         } else if (objectSha && objectType === 'commit') {
@@ -96,12 +104,17 @@ export async function getTagInfo(
               if (!date && authorDate) {
                 date = new Date(authorDate)
               }
-            } catch {
-              /* Ignore commit fetch errors. */
+            } catch (commitError: unknown) {
+              if (isRateLimit(commitError)) {
+                throw commitError
+              }
             }
           }
         }
-      } catch {
+      } catch (referenceError: unknown) {
+        if (isRateLimit(referenceError)) {
+          throw referenceError
+        }
         if (isLikelySha(releaseData.target_commitish)) {
           sha = releaseData.target_commitish
         }
@@ -110,7 +123,16 @@ export async function getTagInfo(
       let result: TagInfo = { tag: displayTag, message, date, sha }
       context.caches.tagInfo.set(cacheKey, result)
       return result
-    } catch {
+    } catch (releaseError: unknown) {
+      /**
+       * A rate limit reaches here from the release request itself or from any
+       * of the metadata requests above. Retrying the refs fallback would spend
+       * another request on the same exhausted budget.
+       */
+      if (isRateLimit(releaseError)) {
+        throw releaseError
+      }
+
       try {
         let referenceResp = await makeRequest(
           context,
@@ -137,7 +159,11 @@ export async function getTagInfo(
             sha = tagData.object.sha ?? sha
             message = tagData.message ?? null
             date = tagData.tagger.date ? new Date(tagData.tagger.date) : null
-          } catch {}
+          } catch (tagObjectError: unknown) {
+            if (isRateLimit(tagObjectError)) {
+              throw tagObjectError
+            }
+          }
         } else {
           try {
             let commitResp = await makeRequest(
@@ -151,8 +177,10 @@ export async function getTagInfo(
             message = commitData.message ?? null
             date =
               commitData.author.date ? new Date(commitData.author.date) : null
-          } catch {
-            /* Ignore commit fetch errors. */
+          } catch (commitError: unknown) {
+            if (isRateLimit(commitError)) {
+              throw commitError
+            }
           }
         }
 
@@ -166,10 +194,7 @@ export async function getTagInfo(
          * Otherwise the caller reads a rate-limited lookup as a tag without a
          * publication date.
          */
-        if (
-          tagError instanceof Error &&
-          tagError.message.includes('rate limit')
-        ) {
+        if (isRateLimit(tagError)) {
           throw tagError
         }
         if (tagError && typeof tagError === 'object' && 'status' in tagError) {
@@ -180,7 +205,7 @@ export async function getTagInfo(
       }
     }
   } catch (error) {
-    if (error instanceof Error && error.message.includes('rate limit')) {
+    if (isRateLimit(error)) {
       throw new GitHubRateLimitError(context.rateLimitReset)
     }
     throw error
@@ -193,4 +218,14 @@ function isLikelySha(value: unknown): value is string {
   }
   let normalized = value.replace(/^v/u, '')
   return /^[0-9a-f]{7,40}$/iu.test(normalized)
+}
+
+/**
+ * Recognize the rate limit that `makeRequest` reports as a rewritten message.
+ *
+ * @param error - Error thrown by a metadata request.
+ * @returns True when the request was rate limited.
+ */
+function isRateLimit(error: unknown): error is Error {
+  return error instanceof Error && error.message.includes('rate limit')
 }

--- a/core/api/get-tag-info.ts
+++ b/core/api/get-tag-info.ts
@@ -15,6 +15,8 @@ import { makeRequest } from './make-request'
  * @param parameters.repo - Repository name.
  * @param parameters.tag - Tag name (may include 'refs/tags/' prefix).
  * @returns TagInfo object or null when tag cannot be found.
+ * @throws GitHubRateLimitError - When a request was rate limited, so the caller
+ *   reports the rate limit instead of reading the tag as undated.
  */
 export async function getTagInfo(
   context: GitHubClientContext,
@@ -158,6 +160,18 @@ export async function getTagInfo(
         context.caches.tagInfo.set(cacheKey, result)
         return result
       } catch (tagError: unknown) {
+        /**
+         * A rate limit arrives as a 403, so it has to be recognized before the
+         * status check below turns every HTTP failure into "tag not found".
+         * Otherwise the caller reads a rate-limited lookup as a tag without a
+         * publication date.
+         */
+        if (
+          tagError instanceof Error &&
+          tagError.message.includes('rate limit')
+        ) {
+          throw tagError
+        }
         if (tagError && typeof tagError === 'object' && 'status' in tagError) {
           context.caches.tagInfo.set(cacheKey, null)
           return null

--- a/core/versions/find-compatible-tags.ts
+++ b/core/versions/find-compatible-tags.ts
@@ -7,29 +7,34 @@ import { isSameTagFamily } from './is-same-tag-family'
 import { parseTagFamily } from './parse-tag-family'
 
 /**
- * Pick the newest compatible tag for the provided update mode.
+ * Rank the compatible tags for the provided update mode, newest first.
  *
  * Compatibility rules:
  *
+ * - `major`: greater than current.
  * - `minor`: same major, greater than current.
  * - `patch`: same major and minor, greater than current.
  *
  * Only tags from the current reference's own tag family are considered.
  *
+ * A caller that needs one answer takes the first entry. A caller that applies a
+ * further constraint, such as the release age cool-down, walks the list until
+ * an entry satisfies it.
+ *
  * @param tags - Available tags from GitHub API.
  * @param currentVersion - Current action version.
  * @param mode - Mode that limits the allowed update level.
- * @returns Best compatible tag or null when no compatible candidate exists.
+ * @returns Compatible tags ordered newest first, empty when none qualify.
  */
-export function findCompatibleTag(
+export function findCompatibleTags(
   tags: TagInfo[],
   currentVersion: string | null,
-  mode: Exclude<UpdateMode, 'major'>,
-): TagInfo | null {
+  mode: UpdateMode,
+): TagInfo[] {
   let current = parseTagFamily(currentVersion)
 
   if (!current || tags.length === 0) {
-    return null
+    return []
   }
 
   let currentMajor = semver.major(current.version)
@@ -47,7 +52,7 @@ export function findCompatibleTag(
       continue
     }
 
-    if (semver.major(family.version) !== currentMajor) {
+    if (mode !== 'major' && semver.major(family.version) !== currentMajor) {
       continue
     }
 
@@ -56,10 +61,6 @@ export function findCompatibleTag(
     }
 
     candidates.push({ parsed: family.version, tag: tagInfo })
-  }
-
-  if (candidates.length === 0) {
-    return null
   }
 
   candidates.sort((a, b) => {
@@ -72,5 +73,5 @@ export function findCompatibleTag(
     return bSpecific - aSpecific
   })
 
-  return candidates[0]!.tag
+  return candidates.map(candidate => candidate.tag)
 }

--- a/core/versions/find-compatible-tags.ts
+++ b/core/versions/find-compatible-tags.ts
@@ -17,26 +17,38 @@ import { parseTagFamily } from './parse-tag-family'
  *
  * Only tags from the current reference's own tag family are considered.
  *
+ * Prerelease members are ignored unless the current version is itself a
+ * prerelease, so a step-down never lands on the release candidate that a stable
+ * release was cut from.
+ *
  * A caller that needs one answer takes the first entry. A caller that applies a
  * further constraint, such as the release age cool-down, walks the list until
  * an entry satisfies it.
  *
  * @param tags - Available tags from GitHub API.
  * @param currentVersion - Current action version.
- * @param mode - Mode that limits the allowed update level.
+ * @param parameters - Constraints applied to the ranking.
+ * @param parameters.latestVersion - Newest version the caller already vetted.
+ *   Tags above it are ignored, so the walk cannot offer a tag that was never
+ *   released. Omit it, or pass a version that carries no comparable core, to
+ *   rank every compatible tag.
+ * @param parameters.mode - Mode that limits the allowed update level.
  * @returns Compatible tags ordered newest first, empty when none qualify.
  */
 export function findCompatibleTags(
   tags: TagInfo[],
   currentVersion: string | null,
-  mode: UpdateMode,
+  parameters: { latestVersion?: string | null; mode: UpdateMode },
 ): TagInfo[] {
+  let { latestVersion, mode } = parameters
   let current = parseTagFamily(currentVersion)
 
   if (!current || tags.length === 0) {
     return []
   }
 
+  let ceiling = parseTagFamily(latestVersion)?.version ?? null
+  let allowPrerelease = semver.prerelease(current.version) !== null
   let currentMajor = semver.major(current.version)
   let currentMinor = semver.minor(current.version)
   let candidates: { parsed: string; tag: TagInfo }[] = []
@@ -49,6 +61,14 @@ export function findCompatibleTags(
     }
 
     if (!semver.gt(family.version, current.version)) {
+      continue
+    }
+
+    if (!allowPrerelease && semver.prerelease(family.version) !== null) {
+      continue
+    }
+
+    if (ceiling && semver.gt(family.version, ceiling)) {
       continue
     }
 

--- a/readme.md
+++ b/readme.md
@@ -579,6 +579,11 @@ npx actions-up --min-age 7
 Versions resolved from tags (repositories without releases, or `--prefer-tags`
 results) honor the cool-down using the tag's commit or tagger date.
 
+When the latest release is too new, the older releases are checked in turn and
+the newest one that clears the cool-down is offered instead. An action is
+reported as held back only when no release satisfies both the cool-down and
+`--mode`.
+
 Ignore comments (file/block/next-line/inline):
 
 ```yaml

--- a/readme.md
+++ b/readme.md
@@ -580,9 +580,10 @@ Versions resolved from tags (repositories without releases, or `--prefer-tags`
 results) honor the cool-down using the tag's commit or tagger date.
 
 When the latest release is too new, the older releases are checked in turn and
-the newest one that clears the cool-down is offered instead. An action is
-reported as held back only when no release satisfies both the cool-down and
-`--mode`.
+the newest one that clears the cool-down is offered instead. The walk never
+rises above the latest release, and it skips prereleases unless the pinned
+version is itself a prerelease. An action is reported as held back only when no
+release satisfies both the cool-down and `--mode`.
 
 Ignore comments (file/block/next-line/inline):
 

--- a/test/api/get-compatible-update.test.ts
+++ b/test/api/get-compatible-update.test.ts
@@ -4,6 +4,9 @@ import type { GitHubClient } from '../../types/github-client'
 
 import { getCompatibleUpdate } from '../../core/api/get-compatible-update'
 
+const DAY = 24 * 60 * 60 * 1000
+const NOW = Date.parse('2026-09-04T00:00:00.000Z')
+
 function createClient(overrides: Partial<GitHubClient> = {}): GitHubClient {
   return {
     getMatchingTagReferences: vi.fn().mockResolvedValue([]),
@@ -19,8 +22,27 @@ function createClient(overrides: Partial<GitHubClient> = {}): GitHubClient {
   }
 }
 
+/**
+ * Build a `getTagInfo` mock that answers from a tag-to-age table.
+ *
+ * @param ages - Tag name mapped to its age in days.
+ * @returns Mock resolving each known tag to a dated `TagInfo`.
+ */
+function createTagInfoMock(
+  ages: Record<string, number>,
+): GitHubClient['getTagInfo'] {
+  return vi.fn((_owner: string, _repo: string, tag: string) => {
+    let age = ages[tag]
+    return Promise.resolve(
+      age === undefined ? null : (
+        { date: new Date(NOW - age * DAY), message: null, sha: null, tag }
+      ),
+    )
+  })
+}
+
 describe('getCompatibleUpdate', () => {
-  it('returns null for non-semver current version without API call', async () => {
+  it('reports no candidate for non-semver current version without API call', async () => {
     let client = createClient()
 
     let result = await getCompatibleUpdate(client, {
@@ -29,11 +51,11 @@ describe('getCompatibleUpdate', () => {
       mode: 'minor',
     })
 
-    expect(result).toBeNull()
+    expect(result).toEqual({ reason: 'no-candidate', update: null })
     expect(client.getAllTags).not.toHaveBeenCalled()
   })
 
-  it('returns null for action name without owner/repo', async () => {
+  it('reports no candidate for action name without owner/repo', async () => {
     let client = createClient()
 
     let result = await getCompatibleUpdate(client, {
@@ -42,10 +64,10 @@ describe('getCompatibleUpdate', () => {
       mode: 'minor',
     })
 
-    expect(result).toBeNull()
+    expect(result).toEqual({ reason: 'no-candidate', update: null })
   })
 
-  it('returns null for action name with missing owner', async () => {
+  it('reports no candidate for action name with missing owner', async () => {
     let client = createClient()
 
     let result = await getCompatibleUpdate(client, {
@@ -54,10 +76,10 @@ describe('getCompatibleUpdate', () => {
       mode: 'minor',
     })
 
-    expect(result).toBeNull()
+    expect(result).toEqual({ reason: 'no-candidate', update: null })
   })
 
-  it('returns null when fetching tags fails', async () => {
+  it('reports no candidate when fetching tags fails', async () => {
     let client = createClient({
       getAllTags: vi.fn().mockRejectedValue(new Error('boom')),
     })
@@ -68,10 +90,10 @@ describe('getCompatibleUpdate', () => {
       mode: 'minor',
     })
 
-    expect(result).toBeNull()
+    expect(result).toEqual({ reason: 'no-candidate', update: null })
   })
 
-  it('returns null when no compatible tags exist', async () => {
+  it('reports no candidate when no compatible tags exist', async () => {
     let client = createClient({
       getAllTags: vi
         .fn()
@@ -86,7 +108,7 @@ describe('getCompatibleUpdate', () => {
       mode: 'minor',
     })
 
-    expect(result).toBeNull()
+    expect(result).toEqual({ reason: 'no-candidate', update: null })
   })
 
   it('returns compatible tag with sha from tags list', async () => {
@@ -104,8 +126,12 @@ describe('getCompatibleUpdate', () => {
       mode: 'minor',
     })
 
-    expect(result).toEqual({ version: 'v4.3.0', sha: 'sha-430' })
+    expect(result).toEqual({
+      update: { version: 'v4.3.0', publishedAt: null, sha: 'sha-430' },
+      reason: null,
+    })
     expect(client.getTagSha).not.toHaveBeenCalled()
+    expect(client.getTagInfo).not.toHaveBeenCalled()
   })
 
   it('resolves missing tag sha via getTagSha', async () => {
@@ -124,7 +150,10 @@ describe('getCompatibleUpdate', () => {
       mode: 'patch',
     })
 
-    expect(result).toEqual({ sha: 'resolved-sha', version: 'v4.2.4' })
+    expect(result).toEqual({
+      update: { sha: 'resolved-sha', version: 'v4.2.4', publishedAt: null },
+      reason: null,
+    })
     expect(client.getTagSha).toHaveBeenCalledWith('owner', 'repo', 'v4.2.4')
   })
 
@@ -144,7 +173,10 @@ describe('getCompatibleUpdate', () => {
       mode: 'patch',
     })
 
-    expect(result).toEqual({ version: 'v4.2.4', sha: null })
+    expect(result).toEqual({
+      update: { version: 'v4.2.4', publishedAt: null, sha: null },
+      reason: null,
+    })
   })
 
   it('uses tags and sha caches when provided', async () => {
@@ -165,7 +197,10 @@ describe('getCompatibleUpdate', () => {
       shaCache,
     })
 
-    expect(result).toEqual({ version: 'v4.2.4', sha: 'cached-sha' })
+    expect(result).toEqual({
+      update: { sha: 'cached-sha', version: 'v4.2.4', publishedAt: null },
+      reason: null,
+    })
     expect(client.getAllTags).not.toHaveBeenCalled()
     expect(client.getTagSha).not.toHaveBeenCalled()
   })
@@ -186,7 +221,10 @@ describe('getCompatibleUpdate', () => {
       shaCache,
     })
 
-    expect(result).toEqual({ version: 'v4.2.4', sha: null })
+    expect(result).toEqual({
+      update: { version: 'v4.2.4', publishedAt: null, sha: null },
+      reason: null,
+    })
     expect(client.getAllTags).not.toHaveBeenCalled()
     expect(client.getTagSha).not.toHaveBeenCalled()
   })
@@ -207,7 +245,10 @@ describe('getCompatibleUpdate', () => {
       mode: 'minor',
     })
 
-    expect(result).toEqual({ version: 'v2.1.0', sha: 'sha-210' })
+    expect(result).toEqual({
+      update: { version: 'v2.1.0', publishedAt: null, sha: 'sha-210' },
+      reason: null,
+    })
     expect(client.getAllTags).toHaveBeenCalledWith('owner', 'repo', 100)
   })
 
@@ -226,12 +267,177 @@ describe('getCompatibleUpdate', () => {
       mode: 'patch',
     })
 
-    expect(result).toEqual({ version: 'actions-v0.1.2', sha: 'sha012' })
+    expect(result).toEqual({
+      update: { version: 'actions-v0.1.2', publishedAt: null, sha: 'sha012' },
+      reason: null,
+    })
     expect(client.getMatchingTagReferences).toHaveBeenCalledExactlyOnceWith(
       'owner',
       'repo',
       'actions-',
     )
     expect(client.getAllTags).not.toHaveBeenCalled()
+  })
+
+  it('steps down to the newest tag that clears the cool-down', async () => {
+    let client = createClient({
+      getAllTags: vi.fn().mockResolvedValue([
+        { sha: 'sha-063', tag: 'v0.6.3', message: null, date: null },
+        { sha: 'sha-062', tag: 'v0.6.2', message: null, date: null },
+        { sha: 'sha-061', tag: 'v0.6.1', message: null, date: null },
+      ]),
+      getTagInfo: createTagInfoMock({
+        'v0.6.2': 34,
+        'v0.6.1': 90,
+        'v0.6.3': 5,
+      }),
+    })
+
+    let result = await getCompatibleUpdate(client, {
+      actionName: 'owner/repo',
+      currentVersion: 'v0.6.0',
+      minAgeMs: 7 * DAY,
+      mode: 'major',
+      now: NOW,
+    })
+
+    expect(result).toEqual({
+      update: {
+        publishedAt: new Date(NOW - 34 * DAY),
+        version: 'v0.6.2',
+        sha: 'sha-062',
+      },
+      reason: null,
+    })
+    expect(client.getTagInfo).toHaveBeenCalledTimes(2)
+  })
+
+  it('reports a cool-down when every compatible tag is too young', async () => {
+    let client = createClient({
+      getAllTags: vi.fn().mockResolvedValue([
+        { sha: 'sha-063', tag: 'v0.6.3', message: null, date: null },
+        { sha: 'sha-062', tag: 'v0.6.2', message: null, date: null },
+      ]),
+      getTagInfo: createTagInfoMock({ 'v0.6.3': 1, 'v0.6.2': 2 }),
+    })
+
+    let result = await getCompatibleUpdate(client, {
+      actionName: 'owner/repo',
+      currentVersion: 'v0.6.0',
+      minAgeMs: 7 * DAY,
+      mode: 'major',
+      now: NOW,
+    })
+
+    expect(result).toEqual({ reason: 'cool-down', update: null })
+  })
+
+  it('treats an unknown publication date as old enough', async () => {
+    let client = createClient({
+      getAllTags: vi
+        .fn()
+        .mockResolvedValue([
+          { sha: 'sha-063', tag: 'v0.6.3', message: null, date: null },
+        ]),
+      getTagInfo: vi.fn().mockResolvedValue(null),
+    })
+
+    let result = await getCompatibleUpdate(client, {
+      actionName: 'owner/repo',
+      currentVersion: 'v0.6.0',
+      minAgeMs: 7 * DAY,
+      mode: 'major',
+      now: NOW,
+    })
+
+    expect(result).toEqual({
+      update: { publishedAt: null, version: 'v0.6.3', sha: 'sha-063' },
+      reason: null,
+    })
+  })
+
+  it('treats a failed date lookup as old enough', async () => {
+    let client = createClient({
+      getAllTags: vi
+        .fn()
+        .mockResolvedValue([
+          { sha: 'sha-063', tag: 'v0.6.3', message: null, date: null },
+        ]),
+      getTagInfo: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+
+    let result = await getCompatibleUpdate(client, {
+      actionName: 'owner/repo',
+      currentVersion: 'v0.6.0',
+      minAgeMs: 7 * DAY,
+      mode: 'major',
+      now: NOW,
+    })
+
+    expect(result).toEqual({
+      update: { publishedAt: null, version: 'v0.6.3', sha: 'sha-063' },
+      reason: null,
+    })
+  })
+
+  it('takes the tag sha from the date lookup when the listing has none', async () => {
+    let client = createClient({
+      getTagInfo: vi.fn().mockResolvedValue({
+        date: new Date(NOW - 34 * DAY),
+        sha: 'sha-from-info',
+        tag: 'v0.6.2',
+        message: null,
+      }),
+      getAllTags: vi
+        .fn()
+        .mockResolvedValue([
+          { tag: 'v0.6.2', message: null, date: null, sha: null },
+        ]),
+    })
+
+    let result = await getCompatibleUpdate(client, {
+      actionName: 'owner/repo',
+      currentVersion: 'v0.6.0',
+      minAgeMs: 7 * DAY,
+      mode: 'major',
+      now: NOW,
+    })
+
+    expect(result).toEqual({
+      update: {
+        publishedAt: new Date(NOW - 34 * DAY),
+        sha: 'sha-from-info',
+        version: 'v0.6.2',
+      },
+      reason: null,
+    })
+    expect(client.getTagSha).not.toHaveBeenCalled()
+  })
+
+  it('honours the mode while stepping down for the cool-down', async () => {
+    let client = createClient({
+      getAllTags: vi.fn().mockResolvedValue([
+        { sha: 'sha-200', tag: 'v2.0.0', message: null, date: null },
+        { sha: 'sha-130', tag: 'v1.3.0', message: null, date: null },
+      ]),
+      getTagInfo: createTagInfoMock({ 'v2.0.0': 90, 'v1.3.0': 34 }),
+    })
+
+    let result = await getCompatibleUpdate(client, {
+      actionName: 'owner/repo',
+      currentVersion: 'v1.2.0',
+      minAgeMs: 7 * DAY,
+      mode: 'minor',
+      now: NOW,
+    })
+
+    expect(result).toEqual({
+      update: {
+        publishedAt: new Date(NOW - 34 * DAY),
+        version: 'v1.3.0',
+        sha: 'sha-130',
+      },
+      reason: null,
+    })
   })
 })

--- a/test/api/get-compatible-update.test.ts
+++ b/test/api/get-compatible-update.test.ts
@@ -7,6 +7,13 @@ import { getCompatibleUpdate } from '../../core/api/get-compatible-update'
 const DAY = 24 * 60 * 60 * 1000
 const NOW = Date.parse('2026-09-04T00:00:00.000Z')
 
+class GitHubRateLimitError extends Error {
+  public constructor() {
+    super('API rate limit exceeded')
+    this.name = 'GitHubRateLimitError'
+  }
+}
+
 function createClient(overrides: Partial<GitHubClient> = {}): GitHubClient {
   return {
     getMatchingTagReferences: vi.fn().mockResolvedValue([]),
@@ -378,6 +385,29 @@ describe('getCompatibleUpdate', () => {
       update: { publishedAt: null, version: 'v0.6.3', sha: 'sha-063' },
       reason: null,
     })
+  })
+
+  it('reports a rate limited date lookup instead of treating it as old enough', async () => {
+    let rateLimit = new GitHubRateLimitError()
+
+    let client = createClient({
+      getAllTags: vi
+        .fn()
+        .mockResolvedValue([
+          { sha: 'sha-063', tag: 'v0.6.3', message: null, date: null },
+        ]),
+      getTagInfo: vi.fn().mockRejectedValue(rateLimit),
+    })
+
+    await expect(
+      getCompatibleUpdate(client, {
+        actionName: 'owner/repo',
+        currentVersion: 'v0.6.0',
+        minAgeMs: 7 * DAY,
+        mode: 'major',
+        now: NOW,
+      }),
+    ).rejects.toThrow(rateLimit)
   })
 
   it('takes the tag sha from the date lookup when the listing has none', async () => {

--- a/test/api/get-tag-info.test.ts
+++ b/test/api/get-tag-info.test.ts
@@ -881,6 +881,25 @@ describe('getTagInfo', () => {
     ).rejects.toHaveProperty('name', 'GitHubRateLimitError')
   })
 
+  it('throws GitHubRateLimitError when the API answers 403 with a rate limit', async () => {
+    let context = makeContext()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(() => {
+      /**
+       * A fresh response per request, because the body is read once.
+       */
+      let response = new Response('API rate limit exceeded', {
+        statusText: 'Forbidden',
+        status: 403,
+      })
+      return Promise.resolve(response)
+    })
+
+    await expect(
+      getTagInfo(context, { tag: 'v5.1.0', owner: 'o', repo: 'r' }),
+    ).rejects.toHaveProperty('name', 'GitHubRateLimitError')
+    expect(context.caches.tagInfo.has('o/r#v5.1.0')).toBeFalsy()
+  })
+
   it('rethrows unexpected errors from both release and fallback paths', async () => {
     let context = makeContext()
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('fatal'))

--- a/test/api/get-tag-info.test.ts
+++ b/test/api/get-tag-info.test.ts
@@ -1056,6 +1056,178 @@ describe('getTagInfo', () => {
       sha: null,
     })
   })
+
+  /**
+   * A fresh response per call, because the body is read once.
+   *
+   * @returns A rate-limited 403 response.
+   */
+  function rateLimited(): Promise<Response> {
+    return Promise.resolve(
+      new Response('API rate limit exceeded', {
+        statusText: 'Forbidden',
+        status: 403,
+      }),
+    )
+  }
+
+  function respond(body: unknown): Promise<Response> {
+    return Promise.resolve(new Response(JSON.stringify(body), { status: 200 }))
+  }
+
+  function notFound(): Promise<Response> {
+    return Promise.resolve(
+      new Response('Not Found', { statusText: 'Not Found', status: 404 }),
+    )
+  }
+
+  it('throws when the annotated tag lookup is rate limited after a release', async () => {
+    let context = makeContext()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+      let input = url as unknown
+      let urlString = typeof input === 'string' ? input : (input as URL).href
+      if (urlString.endsWith('/releases/tags/v7.0.0')) {
+        return respond({
+          published_at: '2024-05-01T00:00:00Z',
+          target_commitish: null,
+          body: 'Release notes',
+        })
+      }
+      if (urlString.endsWith('/git/ref/tags/v7.0.0')) {
+        /* Cspell:disable-next-line */
+        return respond({ object: { sha: 'tagobj7', type: 'tag' } })
+      }
+      return rateLimited()
+    })
+
+    await expect(
+      getTagInfo(context, { tag: 'v7.0.0', owner: 'o', repo: 'r' }),
+    ).rejects.toHaveProperty('name', 'GitHubRateLimitError')
+    expect(context.caches.tagInfo.has('o/r#v7.0.0')).toBeFalsy()
+  })
+
+  it('throws when the commit lookup is rate limited after a release', async () => {
+    let context = makeContext()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+      let input = url as unknown
+      let urlString = typeof input === 'string' ? input : (input as URL).href
+      if (urlString.endsWith('/releases/tags/v7.1.0')) {
+        return respond({
+          target_commitish: null,
+          published_at: null,
+          body: null,
+        })
+      }
+      if (urlString.endsWith('/git/ref/tags/v7.1.0')) {
+        return respond({ object: { sha: 'commit71', type: 'commit' } })
+      }
+      return rateLimited()
+    })
+
+    await expect(
+      getTagInfo(context, { tag: 'v7.1.0', owner: 'o', repo: 'r' }),
+    ).rejects.toHaveProperty('name', 'GitHubRateLimitError')
+    expect(context.caches.tagInfo.has('o/r#v7.1.0')).toBeFalsy()
+  })
+
+  it('throws when the reference lookup is rate limited after a release', async () => {
+    let context = makeContext()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+      let input = url as unknown
+      let urlString = typeof input === 'string' ? input : (input as URL).href
+      if (urlString.endsWith('/releases/tags/v7.2.0')) {
+        return respond({
+          published_at: '2024-05-02T00:00:00Z',
+          target_commitish: 'abcdef1',
+          body: 'Release notes',
+        })
+      }
+      return rateLimited()
+    })
+
+    await expect(
+      getTagInfo(context, { tag: 'v7.2.0', owner: 'o', repo: 'r' }),
+    ).rejects.toHaveProperty('name', 'GitHubRateLimitError')
+    expect(context.caches.tagInfo.has('o/r#v7.2.0')).toBeFalsy()
+  })
+
+  it('throws when the annotated tag lookup is rate limited without a release', async () => {
+    let context = makeContext()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+      let input = url as unknown
+      let urlString = typeof input === 'string' ? input : (input as URL).href
+      if (urlString.endsWith('/releases/tags/v7.3.0')) {
+        return notFound()
+      }
+      if (urlString.endsWith('/git/ref/tags/v7.3.0')) {
+        /* Cspell:disable-next-line */
+        return respond({ object: { sha: 'tagobj73', type: 'tag' } })
+      }
+      return rateLimited()
+    })
+
+    await expect(
+      getTagInfo(context, { tag: 'v7.3.0', owner: 'o', repo: 'r' }),
+    ).rejects.toHaveProperty('name', 'GitHubRateLimitError')
+    expect(context.caches.tagInfo.has('o/r#v7.3.0')).toBeFalsy()
+  })
+
+  it('throws when the commit lookup is rate limited without a release', async () => {
+    let context = makeContext()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+      let input = url as unknown
+      let urlString = typeof input === 'string' ? input : (input as URL).href
+      if (urlString.endsWith('/releases/tags/v7.4.0')) {
+        return notFound()
+      }
+      if (urlString.endsWith('/git/ref/tags/v7.4.0')) {
+        return respond({ object: { sha: 'commit74', type: 'commit' } })
+      }
+      return rateLimited()
+    })
+
+    await expect(
+      getTagInfo(context, { tag: 'v7.4.0', owner: 'o', repo: 'r' }),
+    ).rejects.toHaveProperty('name', 'GitHubRateLimitError')
+    expect(context.caches.tagInfo.has('o/r#v7.4.0')).toBeFalsy()
+  })
+
+  it('keeps the release metadata when the commit lookup fails outright', async () => {
+    let context = makeContext()
+    vi.spyOn(globalThis, 'fetch').mockImplementation(url => {
+      let input = url as unknown
+      let urlString = typeof input === 'string' ? input : (input as URL).href
+      if (urlString.endsWith('/releases/tags/v7.5.0')) {
+        return respond({
+          target_commitish: null,
+          published_at: null,
+          body: null,
+        })
+      }
+      if (urlString.endsWith('/git/ref/tags/v7.5.0')) {
+        return respond({ object: { sha: 'commit75', type: 'commit' } })
+      }
+      return Promise.resolve(
+        new Response('Server Error', {
+          statusText: 'Server Error',
+          status: 500,
+        }),
+      )
+    })
+
+    let info = await getTagInfo(context, {
+      tag: 'v7.5.0',
+      owner: 'o',
+      repo: 'r',
+    })
+
+    expect(info).toEqual({
+      sha: 'commit75',
+      tag: 'v7.5.0',
+      message: null,
+      date: null,
+    })
+  })
 })
 
 /* eslint-enable camelcase */

--- a/test/cli/index.test.ts
+++ b/test/cli/index.test.ts
@@ -375,14 +375,21 @@ describe('run', () => {
         currentVersion: 'c'.repeat(40),
         latestVersion: 'v4.0.0',
       }),
-      createUpdate({ publishedAt: new Date(), latestVersion: 'v4.0.0' }),
+      createUpdate({
+        currentVersion: 'v3.0.0',
+        publishedAt: new Date(),
+        latestVersion: 'v3.1.0',
+      }),
       createUpdate({
         publishedAt: new Date('2020-01-01T00:00:00Z'),
         currentVersion: 'v3.0.0',
         latestVersion: 'v4.0.0',
       }),
     ])
-    vi.mocked(getCompatibleUpdate).mockResolvedValue(null)
+    vi.mocked(getCompatibleUpdate).mockResolvedValue({
+      reason: 'no-candidate',
+      update: null,
+    })
 
     run()
 
@@ -489,8 +496,8 @@ describe('run', () => {
       createUpdate({ currentVersion: 'v3.0.0', latestVersion: 'v4.0.0' }),
     ])
     vi.mocked(getCompatibleUpdate).mockResolvedValue({
-      sha: 'd'.repeat(40),
-      version: 'v3.0.1',
+      update: { sha: 'd'.repeat(40), version: 'v3.0.1', publishedAt: null },
+      reason: null,
     })
     vi.mocked(resolveTargetReference).mockResolvedValue(
       createUpdate({ targetRefStyle: 'tag', targetRef: 'v3.0.1' }),
@@ -505,6 +512,104 @@ describe('run', () => {
     })
 
     expect(vi.mocked(getCompatibleUpdate).mock.calls).toHaveLength(1)
+    expect(printModeWarning).not.toHaveBeenCalled()
+  })
+
+  it('steps down to an older release when the cool-down holds the latest', async () => {
+    process.argv = ['node', 'actions-up', '--min-age', '7', '--dry-run']
+    let { action } = createUpdate()
+    vi.mocked(scanGitHubActions).mockResolvedValue(createScanResult([action]))
+    vi.mocked(checkUpdates).mockResolvedValue([
+      createUpdate({
+        currentVersion: 'v0.6.0',
+        publishedAt: new Date(),
+        latestVersion: 'v0.6.3',
+        isBreaking: false,
+      }),
+    ])
+    vi.mocked(getCompatibleUpdate).mockResolvedValue({
+      update: {
+        publishedAt: new Date('2026-08-01T00:00:00.000Z'),
+        sha: 'd'.repeat(40),
+        version: 'v0.6.2',
+      },
+      reason: null,
+    })
+    vi.mocked(resolveTargetReference).mockResolvedValue(
+      createUpdate({ targetRefStyle: 'tag', targetRef: 'v0.6.2' }),
+    )
+
+    run()
+
+    await vi.waitFor(() => {
+      expect(consoleInfoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('1 actions would be updated'),
+      )
+    })
+
+    expect(getCompatibleUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        minAgeMs: 7 * 24 * 60 * 60 * 1000,
+        currentVersion: 'v0.6.0',
+        mode: 'major',
+      }),
+    )
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      expect.stringContaining('v0.6.2'),
+    )
+    expect(printMinAgeWarning).not.toHaveBeenCalled()
+  })
+
+  it('reports the cool-down when no release clears it', async () => {
+    process.argv = ['node', 'actions-up', '--min-age', '7']
+    let { action } = createUpdate()
+    vi.mocked(scanGitHubActions).mockResolvedValue(createScanResult([action]))
+    vi.mocked(checkUpdates).mockResolvedValue([
+      createUpdate({
+        currentVersion: 'v0.6.0',
+        publishedAt: new Date(),
+        latestVersion: 'v0.6.3',
+        isBreaking: false,
+      }),
+    ])
+    vi.mocked(getCompatibleUpdate).mockResolvedValue({
+      reason: 'cool-down',
+      update: null,
+    })
+
+    run()
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(printMinAgeWarning).mock.calls).toHaveLength(1)
+    })
+
+    expect(printModeWarning).not.toHaveBeenCalled()
+    expect(resolveTargetReference).not.toHaveBeenCalled()
+  })
+
+  it('blames the cool-down when the mode still had a candidate', async () => {
+    process.argv = ['node', 'actions-up', '--mode', 'minor', '--min-age', '7']
+    let { action } = createUpdate()
+    vi.mocked(scanGitHubActions).mockResolvedValue(createScanResult([action]))
+    vi.mocked(checkUpdates).mockResolvedValue([
+      createUpdate({
+        publishedAt: new Date('2020-01-01T00:00:00.000Z'),
+        currentVersion: 'v3.0.0',
+        latestVersion: 'v4.0.0',
+      }),
+    ])
+    vi.mocked(getCompatibleUpdate).mockResolvedValue({
+      reason: 'cool-down',
+      update: null,
+    })
+
+    run()
+
+    await vi.waitFor(() => {
+      expect(vi.mocked(printMinAgeWarning).mock.calls).toHaveLength(1)
+    })
+
     expect(printModeWarning).not.toHaveBeenCalled()
   })
 
@@ -702,7 +807,10 @@ describe('run', () => {
     vi.mocked(checkUpdates).mockResolvedValue([
       createUpdate({ currentVersion: 'e'.repeat(40), action }),
     ])
-    vi.mocked(getCompatibleUpdate).mockResolvedValue(null)
+    vi.mocked(getCompatibleUpdate).mockResolvedValue({
+      reason: 'no-candidate',
+      update: null,
+    })
 
     run()
 
@@ -731,7 +839,11 @@ describe('run', () => {
         currentVersion: 'c'.repeat(40),
         latestVersion: 'v4.0.0',
       }),
-      createUpdate({ publishedAt: new Date(), latestVersion: 'v4.0.0' }),
+      createUpdate({
+        currentVersion: 'v3.0.0',
+        publishedAt: new Date(),
+        latestVersion: 'v3.1.0',
+      }),
       createUpdate({
         publishedAt: new Date('2020-01-01T00:00:00Z'),
         currentVersion: 'v3.0.0',
@@ -744,7 +856,10 @@ describe('run', () => {
         latestVersion: 'v3.1.0',
       }),
     ])
-    vi.mocked(getCompatibleUpdate).mockResolvedValue(null)
+    vi.mocked(getCompatibleUpdate).mockResolvedValue({
+      reason: 'no-candidate',
+      update: null,
+    })
     vi.mocked(resolveTargetReference).mockResolvedValue(
       createUpdate({
         targetRefRateLimited: true,

--- a/test/cli/index.test.ts
+++ b/test/cli/index.test.ts
@@ -515,6 +515,37 @@ describe('run', () => {
     expect(printModeWarning).not.toHaveBeenCalled()
   })
 
+  it('looks a blocked action up once for every occurrence of it', async () => {
+    process.argv = ['node', 'actions-up', '--mode', 'patch', '--dry-run']
+    let { action } = createUpdate()
+    vi.mocked(scanGitHubActions).mockResolvedValue(createScanResult([action]))
+    vi.mocked(checkUpdates).mockResolvedValue([
+      createUpdate({ currentVersion: 'v3.0.0', latestVersion: 'v4.0.0' }),
+      createUpdate({
+        action: { ...action, file: '/repo/.github/workflows/release.yml' },
+        currentVersion: 'v3.0.0',
+        latestVersion: 'v4.0.0',
+      }),
+    ])
+    vi.mocked(getCompatibleUpdate).mockResolvedValue({
+      update: { sha: 'd'.repeat(40), version: 'v3.0.1', publishedAt: null },
+      reason: null,
+    })
+    vi.mocked(resolveTargetReference).mockResolvedValue(
+      createUpdate({ targetRefStyle: 'tag', targetRef: 'v3.0.1' }),
+    )
+
+    run()
+
+    await vi.waitFor(() => {
+      expect(consoleInfoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('2 actions would be updated'),
+      )
+    })
+
+    expect(vi.mocked(getCompatibleUpdate).mock.calls).toHaveLength(1)
+  })
+
   it('passes the vetted latest version as the step-down ceiling', async () => {
     process.argv = ['node', 'actions-up', '--mode', 'patch', '--dry-run']
     let { action } = createUpdate()

--- a/test/cli/index.test.ts
+++ b/test/cli/index.test.ts
@@ -515,6 +515,35 @@ describe('run', () => {
     expect(printModeWarning).not.toHaveBeenCalled()
   })
 
+  it('passes the vetted latest version as the step-down ceiling', async () => {
+    process.argv = ['node', 'actions-up', '--mode', 'patch', '--dry-run']
+    let { action } = createUpdate()
+    vi.mocked(scanGitHubActions).mockResolvedValue(createScanResult([action]))
+    vi.mocked(checkUpdates).mockResolvedValue([
+      createUpdate({ currentVersion: 'v3.0.0', latestVersion: 'v4.0.0' }),
+    ])
+    vi.mocked(getCompatibleUpdate).mockResolvedValue({
+      update: { sha: 'd'.repeat(40), version: 'v3.0.1', publishedAt: null },
+      reason: null,
+    })
+    vi.mocked(resolveTargetReference).mockResolvedValue(
+      createUpdate({ targetRefStyle: 'tag', targetRef: 'v3.0.1' }),
+    )
+
+    run()
+
+    await vi.waitFor(() => {
+      expect(consoleInfoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('1 actions would be updated'),
+      )
+    })
+
+    expect(getCompatibleUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ latestVersion: 'v4.0.0' }),
+    )
+  })
+
   it('steps down to an older release when the cool-down holds the latest', async () => {
     process.argv = ['node', 'actions-up', '--min-age', '7', '--dry-run']
     let { action } = createUpdate()

--- a/test/versions/find-compatible-tags.test.ts
+++ b/test/versions/find-compatible-tags.test.ts
@@ -1,47 +1,47 @@
 import { describe, expect, it, vi } from 'vitest'
 import semver from 'semver'
 
-import { findCompatibleTag } from '../../core/versions/find-compatible-tag'
+import { findCompatibleTags } from '../../core/versions/find-compatible-tags'
 
-describe('findCompatibleTag', () => {
-  it('returns null when current version is missing', () => {
-    let result = findCompatibleTag(
+describe('findCompatibleTags', () => {
+  it('returns nothing when current version is missing', () => {
+    let result = findCompatibleTags(
       [{ sha: 'sha-420', tag: 'v4.2.0', message: null, date: null }],
       null,
       'minor',
     )
-    expect(result).toBeNull()
+    expect(result).toEqual([])
   })
 
-  it('returns null when current version is not semver-like', () => {
-    let result = findCompatibleTag(
+  it('returns nothing when current version is not semver-like', () => {
+    let result = findCompatibleTags(
       [{ sha: 'sha-420', tag: 'v4.2.0', message: null, date: null }],
       'main',
       'minor',
     )
-    expect(result).toBeNull()
+    expect(result).toEqual([])
   })
 
-  it('returns null when tags list is empty', () => {
-    let result = findCompatibleTag([], 'v4.0.0', 'minor')
-    expect(result).toBeNull()
+  it('returns nothing when tags list is empty', () => {
+    let result = findCompatibleTags([], 'v4.0.0', 'minor')
+    expect(result).toEqual([])
   })
 
-  it('returns null when current version cannot be validated', () => {
+  it('returns nothing when current version cannot be validated', () => {
     let validSpy = vi.spyOn(semver, 'valid').mockReturnValueOnce(null)
 
-    let result = findCompatibleTag(
+    let result = findCompatibleTags(
       [{ sha: 'sha-420', tag: 'v4.2.0', message: null, date: null }],
       'v4.0.0',
       'minor',
     )
 
-    expect(result).toBeNull()
+    expect(result).toEqual([])
     validSpy.mockRestore()
   })
 
-  it('selects highest compatible minor tag', () => {
-    let result = findCompatibleTag(
+  it('ranks compatible minor tags newest first', () => {
+    let result = findCompatibleTags(
       [
         { sha: 'sha-500', tag: 'v5.0.0', message: null, date: null },
         { sha: 'sha-432', tag: 'v4.3.2', message: null, date: null },
@@ -50,12 +50,12 @@ describe('findCompatibleTag', () => {
       'v4.1.0',
       'minor',
     )
-    expect(result?.tag).toBe('v4.3.2')
-    expect(result?.sha).toBe('sha-432')
+    expect(result.map(tag => tag.tag)).toEqual(['v4.3.2', 'v4.2.9'])
+    expect(result[0]?.sha).toBe('sha-432')
   })
 
-  it('selects highest compatible patch tag', () => {
-    let result = findCompatibleTag(
+  it('ranks compatible patch tags newest first', () => {
+    let result = findCompatibleTags(
       [
         { sha: 'sha-430', tag: 'v4.3.0', message: null, date: null },
         { sha: 'sha-424', tag: 'v4.2.4', message: null, date: null },
@@ -64,12 +64,24 @@ describe('findCompatibleTag', () => {
       'v4.2.1',
       'patch',
     )
-    expect(result?.tag).toBe('v4.2.7')
-    expect(result?.sha).toBe('sha-427')
+    expect(result.map(tag => tag.tag)).toEqual(['v4.2.7', 'v4.2.4'])
+  })
+
+  it('keeps other majors in major mode', () => {
+    let result = findCompatibleTags(
+      [
+        { sha: 'sha-600', tag: 'v6.0.0', message: null, date: null },
+        { sha: 'sha-500', tag: 'v5.0.0', message: null, date: null },
+        { sha: 'sha-410', tag: 'v4.1.0', message: null, date: null },
+      ],
+      'v4.0.0',
+      'major',
+    )
+    expect(result.map(tag => tag.tag)).toEqual(['v6.0.0', 'v5.0.0', 'v4.1.0'])
   })
 
   it('ignores versions that are not greater than current', () => {
-    let result = findCompatibleTag(
+    let result = findCompatibleTags(
       [
         { sha: 'sha-400', tag: 'v4.0.0', message: null, date: null },
         { sha: 'sha-399', tag: 'v3.9.9', message: null, date: null },
@@ -77,11 +89,11 @@ describe('findCompatibleTag', () => {
       'v4.0.0',
       'minor',
     )
-    expect(result).toBeNull()
+    expect(result).toEqual([])
   })
 
   it('prefers more specific tag when normalized versions are equal', () => {
-    let result = findCompatibleTag(
+    let result = findCompatibleTags(
       [
         { sha: 'sha-short', message: null, tag: 'v1.1', date: null },
         { sha: 'sha-specific', tag: 'v1.1.0', message: null, date: null },
@@ -89,12 +101,12 @@ describe('findCompatibleTag', () => {
       'v1.0.0',
       'minor',
     )
-    expect(result?.tag).toBe('v1.1.0')
-    expect(result?.sha).toBe('sha-specific')
+    expect(result.map(tag => tag.tag)).toEqual(['v1.1.0', 'v1.1'])
+    expect(result[0]?.sha).toBe('sha-specific')
   })
 
-  it('returns null when no compatible candidate exists for mode', () => {
-    let result = findCompatibleTag(
+  it('returns nothing when no compatible candidate exists for mode', () => {
+    let result = findCompatibleTags(
       [
         { sha: 'sha-430', tag: 'v4.3.0', message: null, date: null },
         { sha: 'sha-500', tag: 'v5.0.0', message: null, date: null },
@@ -102,11 +114,11 @@ describe('findCompatibleTag', () => {
       'v4.2.2',
       'patch',
     )
-    expect(result).toBeNull()
+    expect(result).toEqual([])
   })
 
   it('ignores non-semver tags in candidates list', () => {
-    let result = findCompatibleTag(
+    let result = findCompatibleTags(
       [
         { sha: 'sha-stable', tag: 'stable', message: null, date: null },
         { sha: 'sha-421', tag: 'v4.2.1', message: null, date: null },
@@ -114,7 +126,7 @@ describe('findCompatibleTag', () => {
       'v4.2.0',
       'patch',
     )
-    expect(result?.tag).toBe('v4.2.1')
+    expect(result.map(tag => tag.tag)).toEqual(['v4.2.1'])
   })
 
   it('ignores tags that fail semver validation after normalization', () => {
@@ -123,34 +135,34 @@ describe('findCompatibleTag', () => {
       .mockReturnValueOnce('4.0.0')
       .mockReturnValueOnce(null)
 
-    let result = findCompatibleTag(
+    let result = findCompatibleTags(
       [{ sha: 'sha-421', tag: 'v4.2.1', message: null, date: null }],
       'v4.0.0',
       'minor',
     )
 
-    expect(result).toBeNull()
+    expect(result).toEqual([])
     validSpy.mockRestore()
   })
 
-  it('finds a compatible tag inside a prefixed family', () => {
+  it('finds compatible tags inside a prefixed family', () => {
     let tags = [
       { tag: 'actions-v0.1.2', message: null, date: null, sha: 'a' },
       { tag: 'actions-v0.2.0', message: null, date: null, sha: 'b' },
       { tag: 'v0.9.9', message: null, date: null, sha: 'c' },
     ]
 
-    expect(findCompatibleTag(tags, 'actions-v0.1.1', 'patch')?.tag).toBe(
-      'actions-v0.1.2',
-    )
-    expect(findCompatibleTag(tags, 'actions-v0.1.1', 'minor')?.tag).toBe(
-      'actions-v0.2.0',
-    )
+    expect(
+      findCompatibleTags(tags, 'actions-v0.1.1', 'patch').map(tag => tag.tag),
+    ).toEqual(['actions-v0.1.2'])
+    expect(
+      findCompatibleTags(tags, 'actions-v0.1.1', 'minor').map(tag => tag.tag),
+    ).toEqual(['actions-v0.2.0', 'actions-v0.1.2'])
   })
 
   it('never crosses into another tag family', () => {
     let tags = [{ tag: 'v0.9.9', message: null, date: null, sha: 'c' }]
 
-    expect(findCompatibleTag(tags, 'actions-v0.1.1', 'minor')).toBeNull()
+    expect(findCompatibleTags(tags, 'actions-v0.1.1', 'minor')).toEqual([])
   })
 })

--- a/test/versions/find-compatible-tags.test.ts
+++ b/test/versions/find-compatible-tags.test.ts
@@ -8,7 +8,7 @@ describe('findCompatibleTags', () => {
     let result = findCompatibleTags(
       [{ sha: 'sha-420', tag: 'v4.2.0', message: null, date: null }],
       null,
-      'minor',
+      { mode: 'minor' },
     )
     expect(result).toEqual([])
   })
@@ -17,13 +17,13 @@ describe('findCompatibleTags', () => {
     let result = findCompatibleTags(
       [{ sha: 'sha-420', tag: 'v4.2.0', message: null, date: null }],
       'main',
-      'minor',
+      { mode: 'minor' },
     )
     expect(result).toEqual([])
   })
 
   it('returns nothing when tags list is empty', () => {
-    let result = findCompatibleTags([], 'v4.0.0', 'minor')
+    let result = findCompatibleTags([], 'v4.0.0', { mode: 'minor' })
     expect(result).toEqual([])
   })
 
@@ -33,7 +33,7 @@ describe('findCompatibleTags', () => {
     let result = findCompatibleTags(
       [{ sha: 'sha-420', tag: 'v4.2.0', message: null, date: null }],
       'v4.0.0',
-      'minor',
+      { mode: 'minor' },
     )
 
     expect(result).toEqual([])
@@ -48,7 +48,7 @@ describe('findCompatibleTags', () => {
         { sha: 'sha-429', tag: 'v4.2.9', message: null, date: null },
       ],
       'v4.1.0',
-      'minor',
+      { mode: 'minor' },
     )
     expect(result.map(tag => tag.tag)).toEqual(['v4.3.2', 'v4.2.9'])
     expect(result[0]?.sha).toBe('sha-432')
@@ -62,7 +62,7 @@ describe('findCompatibleTags', () => {
         { sha: 'sha-427', tag: 'v4.2.7', message: null, date: null },
       ],
       'v4.2.1',
-      'patch',
+      { mode: 'patch' },
     )
     expect(result.map(tag => tag.tag)).toEqual(['v4.2.7', 'v4.2.4'])
   })
@@ -75,7 +75,7 @@ describe('findCompatibleTags', () => {
         { sha: 'sha-410', tag: 'v4.1.0', message: null, date: null },
       ],
       'v4.0.0',
-      'major',
+      { mode: 'major' },
     )
     expect(result.map(tag => tag.tag)).toEqual(['v6.0.0', 'v5.0.0', 'v4.1.0'])
   })
@@ -87,7 +87,7 @@ describe('findCompatibleTags', () => {
         { sha: 'sha-399', tag: 'v3.9.9', message: null, date: null },
       ],
       'v4.0.0',
-      'minor',
+      { mode: 'minor' },
     )
     expect(result).toEqual([])
   })
@@ -99,7 +99,7 @@ describe('findCompatibleTags', () => {
         { sha: 'sha-specific', tag: 'v1.1.0', message: null, date: null },
       ],
       'v1.0.0',
-      'minor',
+      { mode: 'minor' },
     )
     expect(result.map(tag => tag.tag)).toEqual(['v1.1.0', 'v1.1'])
     expect(result[0]?.sha).toBe('sha-specific')
@@ -112,7 +112,7 @@ describe('findCompatibleTags', () => {
         { sha: 'sha-500', tag: 'v5.0.0', message: null, date: null },
       ],
       'v4.2.2',
-      'patch',
+      { mode: 'patch' },
     )
     expect(result).toEqual([])
   })
@@ -124,7 +124,7 @@ describe('findCompatibleTags', () => {
         { sha: 'sha-421', tag: 'v4.2.1', message: null, date: null },
       ],
       'v4.2.0',
-      'patch',
+      { mode: 'patch' },
     )
     expect(result.map(tag => tag.tag)).toEqual(['v4.2.1'])
   })
@@ -138,7 +138,7 @@ describe('findCompatibleTags', () => {
     let result = findCompatibleTags(
       [{ sha: 'sha-421', tag: 'v4.2.1', message: null, date: null }],
       'v4.0.0',
-      'minor',
+      { mode: 'minor' },
     )
 
     expect(result).toEqual([])
@@ -153,16 +153,75 @@ describe('findCompatibleTags', () => {
     ]
 
     expect(
-      findCompatibleTags(tags, 'actions-v0.1.1', 'patch').map(tag => tag.tag),
+      findCompatibleTags(tags, 'actions-v0.1.1', { mode: 'patch' }).map(
+        tag => tag.tag,
+      ),
     ).toEqual(['actions-v0.1.2'])
     expect(
-      findCompatibleTags(tags, 'actions-v0.1.1', 'minor').map(tag => tag.tag),
+      findCompatibleTags(tags, 'actions-v0.1.1', { mode: 'minor' }).map(
+        tag => tag.tag,
+      ),
     ).toEqual(['actions-v0.2.0', 'actions-v0.1.2'])
   })
 
   it('never crosses into another tag family', () => {
     let tags = [{ tag: 'v0.9.9', message: null, date: null, sha: 'c' }]
 
-    expect(findCompatibleTags(tags, 'actions-v0.1.1', 'minor')).toEqual([])
+    expect(
+      findCompatibleTags(tags, 'actions-v0.1.1', { mode: 'minor' }),
+    ).toEqual([])
+  })
+
+  it('skips prereleases when the current version is stable', () => {
+    let result = findCompatibleTags(
+      [
+        { tag: 'v4.1.0-rc.1', sha: 'sha-410-rc', message: null, date: null },
+        { sha: 'sha-401', tag: 'v4.0.1', message: null, date: null },
+      ],
+      'v4.0.0',
+      { mode: 'minor' },
+    )
+
+    expect(result.map(tag => tag.tag)).toEqual(['v4.0.1'])
+  })
+
+  it('keeps prereleases when the current version is a prerelease', () => {
+    let result = findCompatibleTags(
+      [
+        { sha: 'sha-410-rc2', tag: 'v4.1.0-rc.2', message: null, date: null },
+        { sha: 'sha-401', tag: 'v4.0.1', message: null, date: null },
+      ],
+      'v4.0.0-rc.1',
+      { mode: 'minor' },
+    )
+
+    expect(result.map(tag => tag.tag)).toEqual(['v4.1.0-rc.2', 'v4.0.1'])
+  })
+
+  it('ignores tags above the vetted latest version', () => {
+    let result = findCompatibleTags(
+      [
+        { sha: 'sha-500', tag: 'v5.0.0', message: null, date: null },
+        { sha: 'sha-430', tag: 'v4.3.0', message: null, date: null },
+        { sha: 'sha-420', tag: 'v4.2.0', message: null, date: null },
+      ],
+      'v4.1.0',
+      { latestVersion: 'v4.3.0', mode: 'major' },
+    )
+
+    expect(result.map(tag => tag.tag)).toEqual(['v4.3.0', 'v4.2.0'])
+  })
+
+  it('ranks every compatible tag when the latest version carries no core', () => {
+    let result = findCompatibleTags(
+      [
+        { sha: 'sha-500', tag: 'v5.0.0', message: null, date: null },
+        { sha: 'sha-430', tag: 'v4.3.0', message: null, date: null },
+      ],
+      'v4.1.0',
+      { latestVersion: 'main', mode: 'major' },
+    )
+
+    expect(result.map(tag => tag.tag)).toEqual(['v5.0.0', 'v4.3.0'])
   })
 })


### PR DESCRIPTION
### Description

Fixes the fallback half of #54. (The `--json` half of that issue is stacked in a follow-up PR.)

**Problem.** When an action's latest release was younger than `--min-age`, the run dropped the action instead of offering the newest release that does clear the cool-down. The `--mode` step-down added in v1.12.0 already behaved this way; the age filter in `cli/index.ts` ran ahead of it and removed the candidate outright. Two consequences:

- No fallback. `getCompatibleUpdate()` took a mode but no age constraint, so it could not express "newest release older than N days".
- Ordering. With `--mode minor --min-age 7`, an action whose latest is a too-new major was dropped for age before the mode logic could offer an eligible minor. And a version the mode substituted never had its own age checked.

**Solution.** Both constraints now go through `getCompatibleUpdate()`:

- `findCompatibleTag` becomes `findCompatibleTags`, returning every compatible tag ranked newest first, and accepts `major`. The default mode is `major`, so without this the fallback would never run for the reported case.
- `getCompatibleUpdate()` takes an optional `minAgeMs` (and `now`). It walks the ranked candidates and takes the first one old enough. Dates come from `getTagInfo`, one candidate at a time, so a one-release step-down does not pay for the whole tag history. Tag listings carry no dates, which is why this cannot be a single request.
- It returns `{ update, reason }` instead of a bare value. `reason` is `cool-down` when the mode had candidates but all were too young, and `no-candidate` when the mode allows nothing newer. The CLI uses that to put the action in the right notice: the cool-down owns the outcome whenever the mode still had something to offer.
- `cli/index.ts` decides mode and age in one pass. An action is reported as held back only when no release satisfies both.

The substituted update also carries its own `publishedAt` and a recomputed `isBreaking`, instead of the previous unconditional `isBreaking: false` and the stale date of the version that was rejected.

**Verified against the repro in the issue** with a build of this branch, a workflow pinned to `zizmorcore/zizmor-action@v0.6.0`:

```console
$ actions-up --dry-run --min-age 7
zizmorcore/zizmor-action: v0.6.0 → v0.6.2 (3dc1ecc)

$ actions-up --dry-run --min-age 0
zizmorcore/zizmor-action: v0.6.0 → v0.6.3 (70fb788)

$ actions-up --dry-run --min-age 90
⏳ Skipped 1 update released less than 90 days ago (cool-down, use --min-age 0 to disable)
   • zizmorcore/zizmor-action@v0.6.0
```

`pnpm test` passes in full, `test:packages` included. Coverage stays at 100%.

**Review follow-ups.** Three commits answer @azat-io's review:

- `fix: report a rate limited tag lookup instead of an undated tag`. `makeRequest` attaches `status: 403`, and the refs fallback in `get-tag-info.ts` checked for `status` before the rate-limit wrapper, so a rate-limited `getTagInfo` cached and returned `null` and both `@throws` contracts were dead. It now recognizes the rate limit first, the way `get-tag-sha.ts` already does.
- `fix: never step down to a prerelease or an unreleased tag`. The ranking skips prereleases unless the current version is one, mirroring `select-latest-family-tag.ts`, and `getCompatibleUpdate` now takes the vetted `latestVersion` as a ceiling.
- `perf: look a blocked action up once for all of its occurrences`. The lookup is memoized per action and version with a promise-valued map, so N workflows using one blocked action no longer fire N tag listings and date walks.

### Reviewer notes

- The age-vs-mode attribution rule is in `cli/index.ts`, in the branch that reads `compatible.reason`. Please check it reads the way you want in the `--mode minor --min-age N` combinations.
- Two tests in `test/cli/index.test.ts` changed fixture rather than expectation. They used a too-new **major** bump to exercise the min-age notice under `--mode minor`. Under the corrected logic that case is genuinely mode-blocked (no eligible minor exists at all), so the fixtures became too-new **minor** bumps.
- `core/versions/find-compatible-tag.ts` is renamed to the plural. The old singular had one caller, and keeping a wrapper would have tripped `knip`.
- `cli/build-json-report.ts` is untouched here; it moves in the follow-up.

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed

