### PR TITLE
build: pin the package manager version

### DIFF
--- a/.github/actions/install-tools/action.yml
+++ b/.github/actions/install-tools/action.yml
@@ -11,5 +11,4 @@ runs:
     - name: Install pnpm
       uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
       with:
-        version: 11
         run_install: false

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "vite-plugin-dts": "^5.1.0",
     "vitest": "^4.1.11"
   },
+  "packageManager": "pnpm@11.25.0",
   "engines": {
     "node": "^18.3.0 || >=20.0.0"
   }


### PR DESCRIPTION
### Description

Fixes #57.

**Problem.** pnpm was pinned only in CI, through the `version: 11` input to `pnpm/action-setup`. Nothing told a contributor's machine which pnpm to use, so an install under pnpm 12 rewrote `pnpm-lock.yaml`: pnpm 11 records a top-level `pnpmfileChecksum` for the pnpmfile that `@pnpm/plugin-trusted-deps` contributes, and pnpm 12 strips it. Since CI installs with `--frozen-lockfile`, the rewrite surfaces as a stray diff in a pull request and a failing `test:packages`. It did in #55.

**Solution.** `"packageManager": "pnpm@11.25.0"` in `package.json`. pnpm honors the field itself — `manage-package-manager-versions` is on by default, so pnpm re-executes the pinned version instead of running whatever is on `PATH`. No corepack required.

`11.25.0` is what `version: 11` already resolved to (`latest-11` on the registry), so CI keeps running the same pnpm.

**Coupled edit.** `pnpm/action-setup` throws `Multiple versions of pnpm specified` when its `version` input disagrees with `packageManager` (`src/install-pnpm/run.ts`, `readTargetVersion`), and `11` is not the exact string `11.25.0`. The input is dropped and the action reads the field instead, which also leaves one place to bump rather than two.

**Verified** with one pnpm 12.1.0 binary, invoked by absolute path in all three cases:

```console
$ cd /tmp && pnpm --version
12.1.0

$ cd actions-up && pnpm --version          # on main
12.1.0

$ cd actions-up && pnpm --version          # on this branch
11.25.0
```

`pnpm install` on this branch leaves `pnpm-lock.yaml` untouched under both binaries. `pnpm test` passes in full, `test:packages` included, coverage at 100%.

### Reviewer notes

- `packageManager` sits after `devDependencies` because `package-json/order-properties` put it there; I let `eslint --fix` choose the position rather than picking one.
- The field also accepts a corepack integrity hash, `pnpm@11.25.0+sha512-…`. I left it out because it adds a second value to update on every bump, but it would fit this repository's posture. Happy to add it — see the open question in #57.
- No lockfile change belongs in this PR. If you see one, it is the bug this PR fixes.

---

### Pre-merge checklist

- [x] No similar open PR exists
- [x] Description explains problem/solution or links an issue
- [x] Tests added/updated when needed
